### PR TITLE
Finish Retrieving Case Histories✅

### DIFF
--- a/lib/core/widgets/app_text_button.dart
+++ b/lib/core/widgets/app_text_button.dart
@@ -59,7 +59,7 @@ class AppTextButton extends StatelessWidget {
     return TextButton.styleFrom(
       fixedSize: Size(
         width ?? 300.w,
-        height ?? 60.h,
+        height ?? 50.h,
       ),
       backgroundColor: filled! ? color ?? AppColors.blue : AppColors.white,
       padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),

--- a/lib/core/widgets/custom_table.dart
+++ b/lib/core/widgets/custom_table.dart
@@ -61,7 +61,7 @@ class _CustomTableState extends State<CustomTable> {
           },
           selected: _selectedRows[index],
           cells: List.generate(widget.fields.length, (cellIndex) {
-            if (widget.rows[index][cellIndex] == 'Edit') {
+            if (widget.fields[cellIndex] == 'Actions') {
               return _buildEditMenuButton();
             }
             if (cellIndex == tappableCellIndex) {

--- a/lib/features/appointments/data/local/models/case_history_model.dart
+++ b/lib/features/appointments/data/local/models/case_history_model.dart
@@ -6,9 +6,9 @@ class CaseHistoryModel {
   final String phone;
   final String petName;
   final String petType;
-  final DateTime date;
+  final String date;
   final String time;
-  final String petCondition;
+  final String petReport;
 
   CaseHistoryModel({
     required this.id,
@@ -18,7 +18,7 @@ class CaseHistoryModel {
     required this.petType,
     required this.date,
     required this.time,
-    required this.petCondition,
+    required this.petReport,
   });
 
   CaseHistoryModel copyWith({
@@ -27,9 +27,9 @@ class CaseHistoryModel {
     String? phone,
     String? petName,
     String? petType,
-    DateTime? date,
+    String? date,
     String? time,
-    String? petCondition,
+    String? petReport,
   }) {
     return CaseHistoryModel(
       id: id ?? this.id,
@@ -39,21 +39,21 @@ class CaseHistoryModel {
       petType: petType ?? this.petType,
       date: date ?? this.date,
       time: time ?? this.time,
-      petCondition: petCondition ?? this.petCondition,
+      petReport: petReport ?? this.petReport,
     );
   }
 
   factory CaseHistoryModel.fromFirestore(
-      DocumentSnapshot<Map<String, dynamic>> snapshot) {
+      String id, DocumentSnapshot<Map<String, dynamic>> snapshot) {
     return CaseHistoryModel(
-      id: snapshot['id'],
+      id: id,
       ownerName: snapshot['ownerName'],
       phone: snapshot['phone'],
       petName: snapshot['petName'],
       petType: snapshot['petType'],
-      date: DateTime.parse(snapshot['date']),
+      date: snapshot['date'],
       time: snapshot['time'],
-      petCondition: snapshot['petCondition'],
+      petReport: snapshot['petReport'],
     );
   }
 
@@ -64,9 +64,22 @@ class CaseHistoryModel {
       'phone': phone,
       'petName': petName,
       'petType': petType,
-      'date': date.toIso8601String(),
+      'date': date,
       'time': time,
-      'petCondition': petCondition,
+      'petReport': petReport,
     };
+  }
+
+  List<String> toList() {
+    return [
+      id,
+      ownerName,
+      phone,
+      petName,
+      date,
+      petType,
+      time,
+      petReport,
+    ];
   }
 }

--- a/lib/features/appointments/data/local/repos/case_history_repo.dart
+++ b/lib/features/appointments/data/local/repos/case_history_repo.dart
@@ -1,10 +1,14 @@
-import 'package:el_sharq_clinic/features/appointments/data/local/models/appointment_model.dart';
+import 'package:el_sharq_clinic/features/appointments/data/local/models/case_history_model.dart';
 import 'package:el_sharq_clinic/features/appointments/data/remote/case_history_firebase_services.dart';
 
 class CaseHistoryRepo {
   final CaseHistoryFirebaseServices _caseHistoryFirebaseServices;
 
   CaseHistoryRepo(this._caseHistoryFirebaseServices);
+
+  Future<List<CaseHistoryModel>> getAllCases(int clinicIndex) async {
+    return await _caseHistoryFirebaseServices.getAllCaseHistories(clinicIndex);
+  }
 
   Future<bool> addNewCase(CaseHistoryModel appointment, int clinicIndex) async {
     return await _caseHistoryFirebaseServices.addCase(appointment, clinicIndex);

--- a/lib/features/appointments/logic/cubit/case_history_cubit.dart
+++ b/lib/features/appointments/logic/cubit/case_history_cubit.dart
@@ -2,7 +2,7 @@ import 'package:el_sharq_clinic/core/helpers/extensions.dart';
 import 'package:el_sharq_clinic/core/models/auth_data_model.dart';
 import 'package:el_sharq_clinic/core/widgets/app_dialog.dart';
 import 'package:el_sharq_clinic/core/widgets/app_text_button.dart';
-import 'package:el_sharq_clinic/features/appointments/data/local/models/appointment_model.dart';
+import 'package:el_sharq_clinic/features/appointments/data/local/models/case_history_model.dart';
 import 'package:el_sharq_clinic/features/appointments/data/local/repos/case_history_repo.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -25,6 +25,13 @@ class CaseHistoryCubit extends Cubit<CaseHistoryState> {
 
   void setAuthData(AuthDataModel authenticationData) {
     authData = authenticationData;
+  }
+
+  void getAllCases() async {
+    emit(CaseHistoryLoading());
+    final List<CaseHistoryModel> cases =
+        await _caseHistoryRepo.getAllCases(authData!.clinicIndex);
+    emit(CaseHistorySuccess(cases: cases));
   }
 
   void setupControllers() {
@@ -77,7 +84,7 @@ class CaseHistoryCubit extends Cubit<CaseHistoryState> {
       emptyFields.add('Date');
     }
     if (petReportController.text.trim().isEmpty) {
-      emptyFields.add('Pet condition');
+      emptyFields.add('Pet report');
     }
     return emptyFields;
   }
@@ -90,8 +97,8 @@ class CaseHistoryCubit extends Cubit<CaseHistoryState> {
       petType: petTypeController.text.trim(),
       phone: phoneController.text.trim(),
       time: timeController.text.trim(),
-      date: DateTime.parse(dateController.text.trim()),
-      petCondition: petReportController.text.trim(),
+      date: dateController.text.trim(),
+      petReport: petReportController.text.trim(),
     );
   }
 

--- a/lib/features/appointments/logic/cubit/case_history_state.dart
+++ b/lib/features/appointments/logic/cubit/case_history_state.dart
@@ -15,6 +15,10 @@ final class CaseHistoryLoading extends CaseHistoryState {
 }
 
 final class CaseHistorySuccess extends CaseHistoryState {
+  final List<CaseHistoryModel> cases;
+
+  CaseHistorySuccess({required this.cases});
+
   @override
   void takeAction(BuildContext context) {}
 }

--- a/lib/features/appointments/ui/case_history_section.dart
+++ b/lib/features/appointments/ui/case_history_section.dart
@@ -3,9 +3,9 @@ import 'package:el_sharq_clinic/core/models/auth_data_model.dart';
 import 'package:el_sharq_clinic/core/widgets/app_text_button.dart';
 import 'package:el_sharq_clinic/core/widgets/section_container.dart';
 import 'package:el_sharq_clinic/features/appointments/logic/cubit/case_history_cubit.dart';
+import 'package:el_sharq_clinic/features/appointments/ui/widgets/case_history_bloc_listener.dart';
 import 'package:el_sharq_clinic/features/appointments/ui/widgets/case_history_body.dart';
 import 'package:el_sharq_clinic/features/appointments/ui/widgets/case_history_side_sheet.dart';
-import 'package:el_sharq_clinic/features/appointments/ui/widgets/case_history_bloc_listener.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -17,6 +17,7 @@ class CaseHistorySection extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     context.read<CaseHistoryCubit>().setAuthData(authData);
+    context.read<CaseHistoryCubit>().getAllCases();
     return SectionContainer(
       title: 'Case History',
       actions: [

--- a/lib/features/appointments/ui/widgets/case_history_body.dart
+++ b/lib/features/appointments/ui/widgets/case_history_body.dart
@@ -1,7 +1,9 @@
 import 'package:el_sharq_clinic/core/widgets/custom_table.dart';
 import 'package:el_sharq_clinic/core/widgets/section_details_container.dart';
+import 'package:el_sharq_clinic/features/appointments/logic/cubit/case_history_cubit.dart';
 import 'package:el_sharq_clinic/features/appointments/ui/widgets/case_history_side_sheet.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
 class CaseHistoryBody extends StatelessWidget {
   const CaseHistoryBody({super.key});
@@ -10,83 +12,42 @@ class CaseHistoryBody extends StatelessWidget {
   Widget build(BuildContext context) {
     return SectionDetailsContainer(
       padding: EdgeInsets.zero,
-      child: CustomTable(
-        onTappableIndexSelected: () =>
-            showCaseHistoryideSheet(context, 'Case Details', isNew: false),
-        tappableCellIndex: 0,
-        fields: [
-          'Case ID',
-          'Pet Name',
-          'Owner Name',
-          'Date',
-          'Time',
-          'Actions'
-        ],
-        rows: [
-          ['1', 'Tom', 'Jerry', '12/12/2021', '12:00', 'Edit'],
-          ['2', 'Tom', 'Jerry', '12/12/2021', '12:00', 'Edit'],
-          ['3', 'Tom', 'Jerry', '12/12/2021', '12:00', 'Edit'],
-        ],
+      child: BlocBuilder<CaseHistoryCubit, CaseHistoryState>(
+        builder: (context, state) {
+          if (state is CaseHistorySuccess) {
+            return _buildSuccess(context, state);
+          }
+          return const Center(child: CircularProgressIndicator());
+        },
       ),
-
-      // child: Table(
-      //   border: TableBorder(
-      //     horizontalInside: BorderSide(
-      //       color: Colors.grey,
-      //       style: BorderStyle.solid,
-      //       width: 1.0,
-      //     ),
-      //   ),
-      //   children: [
-      //     TableRow(
-      //       decoration: BoxDecoration(
-      //         color: Colors.grey[200],
-      //       ),
-      //       children: [
-      //         Text(
-      //           'Name',
-      //           style: AppTextStyles.font20DarkGreyMedium,
-      //         ),
-      //         Text(
-      //           'Date',
-      //           style: AppTextStyles.font20DarkGreyMedium,
-      //         ),
-      //         Text(
-      //           'Time',
-      //           style: AppTextStyles.font20DarkGreyMedium,
-      //         ),
-      //         Text(
-      //           'Action',
-      //           style: AppTextStyles.font20DarkGreyMedium,
-      //         ),
-      //       ],
-      //     ),
-      //     TableRow(
-      //       children: [
-      //         Text('Ahmed'),
-      //         Text('12/12/2021'),
-      //         Text('12:00'),
-      //         Text('Edit'),
-      //       ],
-      //     ),
-      //     TableRow(
-      //       children: [
-      //         Text('Mohamed'),
-      //         Text('12/12/2021'),
-      //         Text('12:00'),
-      //         Text('Edit'),
-      //       ],
-      //     ),
-      //     TableRow(
-      //       children: [
-      //         Text('Ali'),
-      //         Text('12/12/2021'),
-      //         Text('12:00'),
-      //         Text('Edit'),
-      //       ],
-      //     ),
-      //   ],
-      // ),
     );
+  }
+
+  CustomTable _buildSuccess(BuildContext context, CaseHistoryState state) {
+    return CustomTable(
+      onTappableIndexSelected: () =>
+          showCaseHistoryideSheet(context, 'Case Details', isNew: false),
+      tappableCellIndex: 0,
+      fields: const [
+        'Case ID',
+        'Owner Name',
+        'Phone',
+        'Pet Name',
+        'Date',
+        'Actions'
+      ],
+      rows: [
+        ..._getRows(state),
+        ..._getRows(state),
+        ..._getRows(state),
+        ..._getRows(state)
+      ],
+    );
+  }
+
+  List<List<String>> _getRows(CaseHistoryState state) {
+    return (state as CaseHistorySuccess).cases.map((caseHistory) {
+      return caseHistory.toList();
+    }).toList();
   }
 }

--- a/lib/features/auth/ui/widgets/auth_bloc_listener.dart
+++ b/lib/features/auth/ui/widgets/auth_bloc_listener.dart
@@ -14,8 +14,6 @@ class AuthBlocListener extends StatelessWidget {
     return BlocListener<AuthCubit, AuthState>(
       listener: (context, state) {
         if (state is AuthLoading) {
-          // check if the dialog is already shown
-          context.pop();
           showDialog<String>(
               context: context,
               barrierDismissible: false,
@@ -39,7 +37,8 @@ class AuthBlocListener extends StatelessWidget {
                   context.pushNamed(AppRoutes.home, arguments: state.authData));
         }
         if (state is AuthFailure) {
-          context.pop();
+          if (ModalRoute.of(context)?.isCurrent != true) context.pop();
+
           showDialog<String>(
             context: context,
             builder: (context) => AppDialog(

--- a/lib/features/home/ui/widgets/custom_app_bar.dart
+++ b/lib/features/home/ui/widgets/custom_app_bar.dart
@@ -15,6 +15,7 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
       padding: const EdgeInsets.symmetric(horizontal: 10),
       decoration: _buildContainerDecoration(),
       child: AppBar(
+        surfaceTintColor: AppColors.white,
         backgroundColor: AppColors.white,
         leading: Image.asset(Assets.assetsImagesPngIconLogo),
         titleSpacing: 5,


### PR DESCRIPTION
- Implement retrieving case histories from firebase in `CaseHistoryFirebaseServices`, `CaseHistoryRepo` and `CaseHistoryCubit`.
- Added `BlocBuilder` widget to wrap the cases table to rebuild it when need.
- Added `toList` method to `CaseHistoryModel` converting model to list to display it in the table in UI.