### PR TITLE
Finish Update and Delete Cases✅

### DIFF
--- a/lib/core/widgets/app_alert_dialog.dart
+++ b/lib/core/widgets/app_alert_dialog.dart
@@ -1,0 +1,73 @@
+import 'package:el_sharq_clinic/core/helpers/extensions.dart';
+import 'package:el_sharq_clinic/core/theming/app_colors.dart';
+import 'package:el_sharq_clinic/core/theming/app_text_styles.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+class AppAlertDialog extends StatelessWidget {
+  const AppAlertDialog({
+    super.key,
+    required this.alertMessage,
+    required this.onConfirm,
+    required this.onCancel,
+  });
+
+  final String alertMessage;
+  final VoidCallback onConfirm;
+  final VoidCallback onCancel;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(10),
+      ),
+      icon: Icon(
+        Icons.warning,
+        color: AppColors.darkGrey.withOpacity(0.75),
+        size: 60.sp,
+      ),
+      contentPadding: const EdgeInsets.symmetric(vertical: 25, horizontal: 0),
+      content: _buildContent(),
+      actions: _getActionsList(context),
+    );
+  }
+
+  List<Widget> _getActionsList(BuildContext context) {
+    return [
+      TextButton(
+        onPressed: () {
+          onCancel;
+          context.pop();
+        },
+        child: const Text(
+          'Cancel',
+          style: AppTextStyles.font14DarkGreyMedium,
+        ),
+      ),
+      TextButton(
+        onPressed: () {
+          onConfirm;
+          context.pop();
+        },
+        child: const Text(
+          'Delete',
+          style: AppTextStyles.font14DarkGreyMedium,
+        ),
+      ),
+    ];
+  }
+
+  Container _buildContent() {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 35, vertical: 10),
+      width: double.infinity,
+      color: AppColors.yellow.withOpacity(0.75),
+      child: Text(
+        alertMessage,
+        style: AppTextStyles.font16DarkGreyMedium,
+        textAlign: TextAlign.center,
+      ),
+    );
+  }
+}

--- a/lib/core/widgets/custom_table.dart
+++ b/lib/core/widgets/custom_table.dart
@@ -4,17 +4,22 @@ import 'package:el_sharq_clinic/core/theming/app_text_styles.dart';
 import 'package:flutter/material.dart';
 
 class CustomTable extends StatefulWidget {
-  const CustomTable(
-      {super.key,
-      required this.fields,
-      required this.rows,
-      this.onTappableIndexSelected,
-      this.tappableCellIndex = -1});
+  const CustomTable({
+    super.key,
+    required this.fields,
+    required this.rows,
+    this.onTappableIndexSelected,
+    this.tappableCellIndex = -1,
+    required this.actionButton,
+    required this.onMultiSelection,
+  });
 
   final List<String> fields;
   final List rows;
-  final VoidCallback? onTappableIndexSelected;
+  final void Function(String id)? onTappableIndexSelected;
   final int? tappableCellIndex;
+  final Widget Function(String id) actionButton;
+  final void Function(List<bool> selectedItems) onMultiSelection;
 
   @override
   State<CustomTable> createState() => _CustomTableState();
@@ -51,18 +56,23 @@ class _CustomTableState extends State<CustomTable> {
       });
 
   List<DataRow> _buildTableRows(BuildContext context,
-          VoidCallback? onCellSelected, int tappableCellIndex) =>
+          Function(String)? onCellSelected, int tappableCellIndex) =>
       List.generate(widget.rows.length, (index) {
         return DataRow(
           onSelectChanged: (bool? selected) {
             setState(() {
               _selectedRows[index] = selected ?? false;
             });
+            if (_selectedRows.any((element) => element)) {
+              widget.onMultiSelection(_selectedRows);
+            } else {
+              widget.onMultiSelection(_selectedRows);
+            }
           },
           selected: _selectedRows[index],
           cells: List.generate(widget.fields.length, (cellIndex) {
             if (widget.fields[cellIndex] == 'Actions') {
-              return _buildEditMenuButton();
+              return _buildEditMenuButton(widget.rows[index][0]);
             }
             if (cellIndex == tappableCellIndex) {
               return _buildTappableCell(
@@ -79,9 +89,13 @@ class _CustomTableState extends State<CustomTable> {
       });
 
   DataCell _buildTappableCell(BuildContext context, int index, int cellIndex,
-      VoidCallback? onCellSelected) {
+      Function(String)? onCellSelected) {
     return DataCell(
-      onTap: onCellSelected,
+      onTap: () {
+        if (onCellSelected != null) {
+          onCellSelected(widget.rows[index][0]);
+        }
+      },
       Text(
         widget.rows[index][cellIndex],
         style: AppTextStyles.font16DarkGreyMedium,
@@ -89,22 +103,9 @@ class _CustomTableState extends State<CustomTable> {
     );
   }
 
-  DataCell _buildEditMenuButton() {
+  DataCell _buildEditMenuButton(String id) {
     return DataCell(
-      PopupMenuButton(
-        itemBuilder: (context) {
-          return [
-            const PopupMenuItem(
-              value: 'Edit',
-              child: Text('Edit'),
-            ),
-            const PopupMenuItem(
-              value: 'Delete',
-              child: Text('Delete'),
-            ),
-          ];
-        },
-      ),
+      widget.actionButton(id),
     );
   }
 }

--- a/lib/features/appointments/data/local/models/case_history_model.dart
+++ b/lib/features/appointments/data/local/models/case_history_model.dart
@@ -1,7 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 class CaseHistoryModel {
-  final String id;
+  final String? id;
   final String ownerName;
   final String phone;
   final String petName;
@@ -11,7 +11,7 @@ class CaseHistoryModel {
   final String petReport;
 
   CaseHistoryModel({
-    required this.id,
+    this.id,
     required this.ownerName,
     required this.phone,
     required this.petName,
@@ -59,7 +59,6 @@ class CaseHistoryModel {
 
   Map<String, dynamic> toFirestore() {
     return {
-      'id': id,
       'ownerName': ownerName,
       'phone': phone,
       'petName': petName,
@@ -72,7 +71,7 @@ class CaseHistoryModel {
 
   List<String> toList() {
     return [
-      id,
+      id ?? '',
       ownerName,
       phone,
       petName,

--- a/lib/features/appointments/data/local/repos/case_history_repo.dart
+++ b/lib/features/appointments/data/local/repos/case_history_repo.dart
@@ -14,15 +14,13 @@ class CaseHistoryRepo {
     return await _caseHistoryFirebaseServices.addCase(appointment, clinicIndex);
   }
 
-  // Future<List<AppointmentModel>> getCaseHistory() async {
-  //   return _CaseHistoryFirebaseServices.getCaseHistory();
-  // }
+  Future<bool> updateCase(CaseHistoryModel appointment, int clinicIndex) async {
+    return await _caseHistoryFirebaseServices.updateCase(
+        appointment, clinicIndex);
+  }
 
-  // Future<void> updateAppointment(Appointment appointment) async {
-  //   return localDataSource.updateAppointment(appointment);
-  // }
-
-  // Future<void> deleteAppointment(Appointment appointment) async {
-  //   return localDataSource.deleteAppointment(appointment);
-  // }
+  Future<bool> deleteCase(String appointmentId, int clinicIndex) async {
+    return await _caseHistoryFirebaseServices.deleteCase(
+        appointmentId, clinicIndex);
+  }
 }

--- a/lib/features/appointments/data/remote/case_history_firebase_services.dart
+++ b/lib/features/appointments/data/remote/case_history_firebase_services.dart
@@ -1,3 +1,5 @@
+import 'dart:developer';
+
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:el_sharq_clinic/core/helpers/extensions.dart';
 import 'package:el_sharq_clinic/features/appointments/data/local/models/case_history_model.dart';
@@ -38,7 +40,7 @@ class CaseHistoryFirebaseServices {
   }
 
   Future<bool> addCase(CaseHistoryModel caseHistory, int clinicIndex) async {
-    // Get clinic appointment document
+    // Get clinic cases document
     final clinicDoc = await _getClinicDoc(clinicIndex);
     final clinicCaseHistoryCollection = clinicDoc.reference.collection('cases');
     // Get last CaseHistory to generate new id
@@ -61,14 +63,29 @@ class CaseHistoryFirebaseServices {
   }
 
   Future<bool> updateCase(CaseHistoryModel caseHistory, int clinicIndex) async {
-    // Get clinic appointment document
+    // Get clinic cases document
     final clinicDoc = await _getClinicDoc(clinicIndex);
     final clinicCaseHistoryCollection = clinicDoc.reference.collection('cases');
     // Update CaseHistory in clinic CaseHistory collection
+    log('case history id: ${caseHistory}');
+    log('case history id: ${caseHistory.id}');
+
     try {
       await clinicCaseHistoryCollection
           .doc(caseHistory.id)
           .update(caseHistory.toFirestore());
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  Future<bool> deleteCase(String caseId, int clinicIndex) async {
+    // Get clinic cases document
+    final clinicDoc = await _getClinicDoc(clinicIndex);
+    final clinicCaseHistoryCollection = clinicDoc.reference.collection('cases');
+    try {
+      await clinicCaseHistoryCollection.doc(caseId).delete();
       return true;
     } catch (e) {
       return false;

--- a/lib/features/appointments/logic/cubit/case_history_cubit.dart
+++ b/lib/features/appointments/logic/cubit/case_history_cubit.dart
@@ -14,7 +14,7 @@ class CaseHistoryCubit extends Cubit<CaseHistoryState> {
   CaseHistoryCubit(this._caseHistoryRepo) : super(CaseHistoryInitial());
 
   AuthDataModel? authData;
-  String appointmentId = '';
+  TextEditingController caseIdController = TextEditingController();
   TextEditingController ownerNameController = TextEditingController();
   TextEditingController petNameController = TextEditingController();
   TextEditingController petTypeController = TextEditingController();
@@ -22,6 +22,9 @@ class CaseHistoryCubit extends Cubit<CaseHistoryState> {
   TextEditingController timeController = TextEditingController();
   TextEditingController dateController = TextEditingController();
   TextEditingController petReportController = TextEditingController();
+
+  ValueNotifier<bool> showDeleteButtonNotifier = ValueNotifier(false);
+  List<int> selectedItems = [];
 
   void setAuthData(AuthDataModel authenticationData) {
     authData = authenticationData;
@@ -34,7 +37,7 @@ class CaseHistoryCubit extends Cubit<CaseHistoryState> {
     emit(CaseHistorySuccess(cases: cases));
   }
 
-  void setupControllers() {
+  void setupNewModeControllers() {
     ownerNameController.clear();
     petNameController.clear();
     petTypeController.clear();
@@ -44,27 +47,39 @@ class CaseHistoryCubit extends Cubit<CaseHistoryState> {
     petReportController.text = _getPetReportScheme;
   }
 
+  void setupShowModeControllers(CaseHistoryModel caseHistory) {
+    caseIdController.text = caseHistory.id!;
+    ownerNameController.text = caseHistory.ownerName;
+    petNameController.text = caseHistory.petName;
+    petTypeController.text = caseHistory.petType;
+    phoneController.text = caseHistory.phone;
+    timeController.text = caseHistory.time;
+    dateController.text = caseHistory.date;
+    petReportController.text = _gethandledReportText(caseHistory.petReport);
+  }
+
   void validateAndSaveCase() async {
     final List<String> emptyFields = _getEmptyOfRequiredFields();
     if (emptyFields.isEmpty) {
       emit(NewCaseHistoryLoading());
-      final CaseHistoryModel appointment = _constructAppointment();
+      final CaseHistoryModel newCase = _constructNewCase(update: false);
       final bool successAddition =
-          await _caseHistoryRepo.addNewCase(appointment, authData!.clinicIndex);
+          await _caseHistoryRepo.addNewCase(newCase, authData!.clinicIndex);
       if (successAddition) {
         emit(NewCaseHistorySuccess());
+        getAllCases();
       } else {
         emit(NewCaseHistoryFailure('Failed to add the appointment'));
       }
     } else {
       emit(NewCaseHistoryInvalid(
         title: 'Empty Fields',
-        _getErrorMessage(emptyFields),
+        _getEmptyFieldsMessage(emptyFields),
       ));
     }
   }
 
-  String _getErrorMessage(List<String> emptyFields) {
+  String _getEmptyFieldsMessage(List<String> emptyFields) {
     String errorMessage = 'Please fill the following fields: ';
     for (int i = 0; i < emptyFields.length; i++) {
       errorMessage += emptyFields[i];
@@ -89,27 +104,127 @@ class CaseHistoryCubit extends Cubit<CaseHistoryState> {
     return emptyFields;
   }
 
-  CaseHistoryModel _constructAppointment() {
+  CaseHistoryModel _constructNewCase({required bool update}) {
+    if (update) {
+      return CaseHistoryModel(
+        id: caseIdController.text.trim(),
+        ownerName: ownerNameController.text.trim(),
+        petName: petNameController.text.trim(),
+        petType: petTypeController.text.trim(),
+        phone: phoneController.text.trim(),
+        time: timeController.text.trim(),
+        date: dateController.text.trim(),
+        petReport: _getReportFirebaseText,
+      );
+    }
     return CaseHistoryModel(
-      id: appointmentId,
       ownerName: ownerNameController.text.trim(),
       petName: petNameController.text.trim(),
       petType: petTypeController.text.trim(),
       phone: phoneController.text.trim(),
       time: timeController.text.trim(),
       date: dateController.text.trim(),
-      petReport: petReportController.text.trim(),
+      petReport: _getReportFirebaseText,
     );
   }
 
   String get _getPetReportScheme {
     return """Diagnosis:
 Temp:
-Unique signs : 
-R.R :
-H.R :
-B.W : ..... kg 
-Vaccinations : 
-Treatment :""";
+Unique signs: 
+R.R:
+H.R:
+B.W: ..... kg 
+Vaccinations:
+Treatment:""";
+  }
+
+  String get _getReportFirebaseText {
+    final handledText = petReportController.text
+        .trim()
+        .split('\n')
+        .map((element) {
+          return '$element---n';
+        })
+        .toList()
+        .join();
+    return handledText;
+  }
+
+  String _gethandledReportText(String petReport) {
+    return petReport.replaceAll('---n', '\n');
+  }
+
+  CaseHistoryModel? getCaseHistoryById(String id) {
+    try {
+      return (state as CaseHistorySuccess)
+          .cases
+          .firstWhere((element) => element.id == id);
+    } catch (e) {
+      return null;
+    }
+  }
+
+  void validateAndUpdateCase() async {
+    final List<String> emptyFields = _getEmptyOfRequiredFields();
+    if (emptyFields.isEmpty) {
+      emit(NewCaseHistoryLoading());
+      final CaseHistoryModel updatedCase = _constructNewCase(update: true);
+      final bool success =
+          await _caseHistoryRepo.updateCase(updatedCase, authData!.clinicIndex);
+      if (success) {
+        emit(UpdateCaseHistorySuccess());
+        getAllCases();
+      } else {
+        emit(NewCaseHistoryFailure('Failed to update the case'));
+      }
+    } else {
+      emit(NewCaseHistoryInvalid(
+        title: 'Empty Fields',
+        _getEmptyFieldsMessage(emptyFields),
+      ));
+    }
+  }
+
+  void deleteCase(String caseId) async {
+    emit(CaseHistoryLoading());
+    final bool success =
+        await _caseHistoryRepo.deleteCase(caseId, authData!.clinicIndex);
+    if (success) {
+      getAllCases();
+    } else {
+      emit(CaseHistoryError('Failed to delete the case'));
+    }
+  }
+
+  void onMultiSelection(List<bool> selectedItemsList) {
+    if (selectedItemsList.contains(true)) {
+      for (int i = 0; i < selectedItemsList.length; i++) {
+        if (selectedItemsList[i]) {
+          if (!selectedItems.contains(i)) {
+            selectedItems.add(i);
+          }
+        } else {
+          selectedItems.remove(i);
+        }
+      }
+      showDeleteButtonNotifier.value = true;
+    } else {
+      showDeleteButtonNotifier.value = false;
+    }
+  }
+
+  void deleteSelectedCases() {
+    final cases = (state as CaseHistorySuccess).cases;
+    emit(CaseHistoryLoading());
+    try {
+      for (int i = 0; i < selectedItems.length; i++) {
+        final caseId = cases[selectedItems[i]].id;
+        _caseHistoryRepo.deleteCase(caseId!, authData!.clinicIndex);
+      }
+    } catch (e) {
+      emit(CaseHistoryError('Failed to delete these cases'));
+    }
+    getAllCases();
   }
 }

--- a/lib/features/appointments/logic/cubit/case_history_state.dart
+++ b/lib/features/appointments/logic/cubit/case_history_state.dart
@@ -126,3 +126,24 @@ final class NewCaseHistoryFailure extends CaseHistoryState {
             ));
   }
 }
+
+// Update CaseHistory
+final class UpdateCaseHistorySuccess extends CaseHistoryState {
+  @override
+  void takeAction(BuildContext context) {
+    context.pop();
+
+    context.pop();
+
+    showDialog(
+      context: context,
+      builder: (ctx) => const AppDialog(
+        title: 'Success',
+        content: 'Case updated successfully',
+        dialogType: DialogType.success,
+      ),
+    );
+
+    Future.delayed(const Duration(seconds: 2), () => context.pop());
+  }
+}

--- a/lib/features/appointments/ui/case_history_section.dart
+++ b/lib/features/appointments/ui/case_history_section.dart
@@ -1,11 +1,10 @@
 import 'package:el_sharq_clinic/core/helpers/spacing.dart';
 import 'package:el_sharq_clinic/core/models/auth_data_model.dart';
-import 'package:el_sharq_clinic/core/widgets/app_text_button.dart';
 import 'package:el_sharq_clinic/core/widgets/section_container.dart';
 import 'package:el_sharq_clinic/features/appointments/logic/cubit/case_history_cubit.dart';
 import 'package:el_sharq_clinic/features/appointments/ui/widgets/case_history_bloc_listener.dart';
 import 'package:el_sharq_clinic/features/appointments/ui/widgets/case_history_body.dart';
-import 'package:el_sharq_clinic/features/appointments/ui/widgets/case_history_side_sheet.dart';
+import 'package:el_sharq_clinic/features/appointments/ui/widgets/main_action_button.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -20,14 +19,8 @@ class CaseHistorySection extends StatelessWidget {
     context.read<CaseHistoryCubit>().getAllCases();
     return SectionContainer(
       title: 'Case History',
-      actions: [
-        AppTextButton(
-          text: 'New Case',
-          icon: Icons.book_outlined,
-          onPressed: () =>
-              showCaseHistoryideSheet(context, 'New Case', isNew: true),
-          width: 200,
-        )
+      actions: const [
+        MainActionButton(),
       ],
       child: Expanded(
         child: Column(

--- a/lib/features/appointments/ui/widgets/case_history_action_button.dart
+++ b/lib/features/appointments/ui/widgets/case_history_action_button.dart
@@ -1,0 +1,57 @@
+import 'package:el_sharq_clinic/core/theming/app_text_styles.dart';
+import 'package:el_sharq_clinic/core/widgets/app_alert_dialog.dart';
+import 'package:el_sharq_clinic/features/appointments/logic/cubit/case_history_cubit.dart';
+import 'package:el_sharq_clinic/features/appointments/ui/widgets/case_history_side_sheet.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class CaseHistoryTableActionButton extends StatelessWidget {
+  const CaseHistoryTableActionButton({
+    super.key,
+    required this.id,
+  });
+
+  final String id;
+
+  @override
+  Widget build(BuildContext context) {
+    return PopupMenuButton(
+      itemBuilder: (context) {
+        return [
+          PopupMenuItem(
+            value: 'Edit',
+            onTap: () {
+              final caseHistoryModel =
+                  context.read<CaseHistoryCubit>().getCaseHistoryById(id);
+              showCaseHistoryideSheet(context, 'Edit Case',
+                  caseHistoryModel: caseHistoryModel);
+            },
+            child: const Text(
+              'Edit',
+              style: AppTextStyles.font14DarkGreyMedium,
+            ),
+          ),
+          PopupMenuItem(
+            value: 'Delete',
+            onTap: () {
+              showDialog(
+                context: context,
+                builder: (context) => AppAlertDialog(
+                  alertMessage: 'Are you sure you want to delete this case?\n'
+                      'This action cannot be undone.',
+                  onConfirm: () =>
+                      context.read<CaseHistoryCubit>().deleteCase(id),
+                  onCancel: () {},
+                ),
+              );
+            },
+            child: const Text(
+              'Delete',
+              style: AppTextStyles.font14DarkGreyMedium,
+            ),
+          ),
+        ];
+      },
+    );
+  }
+}

--- a/lib/features/appointments/ui/widgets/case_history_bloc_listener.dart
+++ b/lib/features/appointments/ui/widgets/case_history_bloc_listener.dart
@@ -15,7 +15,8 @@ class CaseHistoryBlocListener extends StatelessWidget {
           current is NewCaseHistoryLoading ||
           current is NewCaseHistoryFailure ||
           current is NewCaseHistorySuccess ||
-          current is NewCaseHistoryInvalid,
+          current is NewCaseHistoryInvalid ||
+          current is UpdateCaseHistorySuccess,
       listener: (context, state) {
         state.takeAction(context);
       },

--- a/lib/features/appointments/ui/widgets/case_history_body.dart
+++ b/lib/features/appointments/ui/widgets/case_history_body.dart
@@ -1,6 +1,7 @@
 import 'package:el_sharq_clinic/core/widgets/custom_table.dart';
 import 'package:el_sharq_clinic/core/widgets/section_details_container.dart';
 import 'package:el_sharq_clinic/features/appointments/logic/cubit/case_history_cubit.dart';
+import 'package:el_sharq_clinic/features/appointments/ui/widgets/case_history_action_button.dart';
 import 'package:el_sharq_clinic/features/appointments/ui/widgets/case_history_side_sheet.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -13,10 +14,20 @@ class CaseHistoryBody extends StatelessWidget {
     return SectionDetailsContainer(
       padding: EdgeInsets.zero,
       child: BlocBuilder<CaseHistoryCubit, CaseHistoryState>(
+        buildWhen: (previous, current) =>
+            current is CaseHistorySuccess ||
+            current is CaseHistoryError ||
+            current is CaseHistoryLoading,
         builder: (context, state) {
           if (state is CaseHistorySuccess) {
             return _buildSuccess(context, state);
           }
+          if (state is CaseHistoryError) {
+            return Center(
+              child: Text(state.errorMessage),
+            );
+          }
+
           return const Center(child: CircularProgressIndicator());
         },
       ),
@@ -25,8 +36,18 @@ class CaseHistoryBody extends StatelessWidget {
 
   CustomTable _buildSuccess(BuildContext context, CaseHistoryState state) {
     return CustomTable(
-      onTappableIndexSelected: () =>
-          showCaseHistoryideSheet(context, 'Case Details', isNew: false),
+      actionButton: (id) => CaseHistoryTableActionButton(
+        id: id,
+      ),
+      onMultiSelection: (selectedItems) {
+        context.read<CaseHistoryCubit>().onMultiSelection(selectedItems);
+      },
+      onTappableIndexSelected: (id) => showCaseHistoryideSheet(
+          editable: false,
+          context,
+          'Case Details',
+          caseHistoryModel:
+              context.read<CaseHistoryCubit>().getCaseHistoryById(id)),
       tappableCellIndex: 0,
       fields: const [
         'Case ID',
@@ -38,9 +59,9 @@ class CaseHistoryBody extends StatelessWidget {
       ],
       rows: [
         ..._getRows(state),
-        ..._getRows(state),
-        ..._getRows(state),
-        ..._getRows(state)
+        // ..._getRows(state),
+        // ..._getRows(state),
+        // ..._getRows(state)
       ],
     );
   }

--- a/lib/features/appointments/ui/widgets/main_action_button.dart
+++ b/lib/features/appointments/ui/widgets/main_action_button.dart
@@ -1,0 +1,59 @@
+import 'package:el_sharq_clinic/core/theming/app_colors.dart';
+import 'package:el_sharq_clinic/core/widgets/app_alert_dialog.dart';
+import 'package:el_sharq_clinic/core/widgets/app_text_button.dart';
+import 'package:el_sharq_clinic/features/appointments/logic/cubit/case_history_cubit.dart';
+import 'package:el_sharq_clinic/features/appointments/ui/widgets/case_history_side_sheet.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class MainActionButton extends StatelessWidget {
+  const MainActionButton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: context.read<CaseHistoryCubit>().showDeleteButtonNotifier,
+      builder: (context, child) => AnimatedSwitcher(
+        duration: const Duration(milliseconds: 500),
+        child: context.read<CaseHistoryCubit>().showDeleteButtonNotifier.value
+            ? _buildDeleteCaseButton(context)
+            : _buildNewCaseButton(context),
+      ),
+    );
+  }
+
+  AppTextButton _buildNewCaseButton(BuildContext context) {
+    return AppTextButton(
+      key: const ValueKey('new_case_button'),
+      text: 'New Case',
+      icon: Icons.book_outlined,
+      onPressed: () => showCaseHistoryideSheet(context, 'New Case'),
+      width: 200,
+    );
+  }
+
+  AppTextButton _buildDeleteCaseButton(BuildContext context) {
+    return AppTextButton(
+      key: const ValueKey('delete_case_button'),
+      text: 'Delete',
+      icon: Icons.delete,
+      color: AppColors.red,
+      onPressed: () {
+        _showDeleteDialog(context);
+      },
+      width: 200,
+    );
+  }
+
+  Future<dynamic> _showDeleteDialog(BuildContext context) {
+    return showDialog(
+      context: context,
+      builder: (context) => AppAlertDialog(
+        alertMessage: 'Are you sure you want to delete these cases?\n'
+            'This action cannot be undone.',
+        onConfirm: () => context.read<CaseHistoryCubit>().deleteSelectedCases(),
+        onCancel: () {},
+      ),
+    );
+  }
+}


### PR DESCRIPTION
- Added `AppAlertDialog` to show alerts to users.
- Made `CustomTable` functional on multi selection and on item tapping.
- Implemented the logic of update and delete in `CaseHistoryFirebaseServices`, `CaseHistoryRepo` and `CaseHistoryCubit`.
- Added `UpdateCaseHistorySuccess` to case history states.
- Created a widget hold the actions that user can take in the main screen of the section.
- Created a widget that hold the actions menu button of the data table.

**Case History Screen Preview**
![image](https://github.com/user-attachments/assets/c3f57ddb-1225-4d99-a896-68bd41b8c493)
