### PR TITLE
Finish Pagination Logic of Cases Section✅

### DIFF
--- a/lib/core/helpers/constants.dart
+++ b/lib/core/helpers/constants.dart
@@ -28,4 +28,14 @@ abstract class AppConstant {
     DrawerItemModel(title: 'Sales', icon: Icons.attach_money_outlined),
     DrawerItemModel(title: 'Settings', icon: Icons.settings_outlined),
   ];
+
+  // Case History
+  static const List<String> casesTableHeaders = [
+    'Case ID',
+    'Owner Name',
+    'Phone',
+    'Pet Name',
+    'Date',
+    ''
+  ];
 }

--- a/lib/core/widgets/app_alert_dialog.dart
+++ b/lib/core/widgets/app_alert_dialog.dart
@@ -1,4 +1,3 @@
-import 'package:el_sharq_clinic/core/helpers/extensions.dart';
 import 'package:el_sharq_clinic/core/theming/app_colors.dart';
 import 'package:el_sharq_clinic/core/theming/app_text_styles.dart';
 import 'package:flutter/material.dart';
@@ -13,8 +12,8 @@ class AppAlertDialog extends StatelessWidget {
   });
 
   final String alertMessage;
-  final VoidCallback onConfirm;
-  final VoidCallback onCancel;
+  final void Function() onConfirm;
+  final void Function() onCancel;
 
   @override
   Widget build(BuildContext context) {
@@ -36,20 +35,14 @@ class AppAlertDialog extends StatelessWidget {
   List<Widget> _getActionsList(BuildContext context) {
     return [
       TextButton(
-        onPressed: () {
-          onCancel;
-          context.pop();
-        },
+        onPressed: onCancel,
         child: const Text(
           'Cancel',
           style: AppTextStyles.font14DarkGreyMedium,
         ),
       ),
       TextButton(
-        onPressed: () {
-          onConfirm;
-          context.pop();
-        },
+        onPressed: onConfirm,
         child: const Text(
           'Delete',
           style: AppTextStyles.font14DarkGreyMedium,

--- a/lib/core/widgets/custom_table.dart
+++ b/lib/core/widgets/custom_table.dart
@@ -1,111 +1,40 @@
 import 'package:data_table_2/data_table_2.dart';
 import 'package:el_sharq_clinic/core/theming/app_colors.dart';
 import 'package:el_sharq_clinic/core/theming/app_text_styles.dart';
+import 'package:el_sharq_clinic/core/widgets/custom_table_data_source.dart';
 import 'package:flutter/material.dart';
 
-class CustomTable extends StatefulWidget {
+class CustomTable extends StatelessWidget {
   const CustomTable({
     super.key,
     required this.fields,
-    required this.rows,
-    this.onTappableIndexSelected,
-    this.tappableCellIndex = -1,
-    required this.actionButton,
-    required this.onMultiSelection,
+    required this.dataSource,
+    required this.onPageChanged,
   });
 
   final List<String> fields;
-  final List rows;
-  final void Function(String id)? onTappableIndexSelected;
-  final int? tappableCellIndex;
-  final Widget Function(String id) actionButton;
-  final void Function(List<bool> selectedItems) onMultiSelection;
-
-  @override
-  State<CustomTable> createState() => _CustomTableState();
-}
-
-class _CustomTableState extends State<CustomTable> {
-  late List<bool> _selectedRows;
-
-  @override
-  void initState() {
-    super.initState();
-    // Initialize the selection state for each row
-    _selectedRows = List<bool>.filled(widget.rows.length, false);
-  }
+  final CustomTableDataSource dataSource;
+  final void Function(int firstIndex) onPageChanged;
 
   @override
   Widget build(BuildContext context) {
     return ClipRRect(
-      borderRadius: BorderRadius.circular(10),
-      child: DataTable2(
-        headingRowColor: const WidgetStatePropertyAll(AppColors.grey),
+      borderRadius: BorderRadius.circular(20),
+      child: PaginatedDataTable2(
+        columnSpacing: 20,
         columns: _buildTableColumns,
-        rows: _buildTableRows(
-            context, widget.onTappableIndexSelected, widget.tappableCellIndex!),
+        source: dataSource,
+        dataRowHeight: 50,
+        headingRowColor: const WidgetStatePropertyAll(AppColors.grey),
+        onPageChanged: onPageChanged,
       ),
     );
   }
 
   List<DataColumn> get _buildTableColumns =>
-      List.generate(widget.fields.length, (index) {
+      List.generate(fields.length, (index) {
         return DataColumn(
-            label: Text(widget.fields[index],
-                style: AppTextStyles.font20DarkGreyMedium));
+            label:
+                Text(fields[index], style: AppTextStyles.font20DarkGreyMedium));
       });
-
-  List<DataRow> _buildTableRows(BuildContext context,
-          Function(String)? onCellSelected, int tappableCellIndex) =>
-      List.generate(widget.rows.length, (index) {
-        return DataRow(
-          onSelectChanged: (bool? selected) {
-            setState(() {
-              _selectedRows[index] = selected ?? false;
-            });
-            if (_selectedRows.any((element) => element)) {
-              widget.onMultiSelection(_selectedRows);
-            } else {
-              widget.onMultiSelection(_selectedRows);
-            }
-          },
-          selected: _selectedRows[index],
-          cells: List.generate(widget.fields.length, (cellIndex) {
-            if (widget.fields[cellIndex] == 'Actions') {
-              return _buildEditMenuButton(widget.rows[index][0]);
-            }
-            if (cellIndex == tappableCellIndex) {
-              return _buildTappableCell(
-                  context, index, cellIndex, onCellSelected);
-            }
-            return DataCell(
-              Text(
-                widget.rows[index][cellIndex],
-                style: AppTextStyles.font16DarkGreyMedium,
-              ),
-            );
-          }),
-        );
-      });
-
-  DataCell _buildTappableCell(BuildContext context, int index, int cellIndex,
-      Function(String)? onCellSelected) {
-    return DataCell(
-      onTap: () {
-        if (onCellSelected != null) {
-          onCellSelected(widget.rows[index][0]);
-        }
-      },
-      Text(
-        widget.rows[index][cellIndex],
-        style: AppTextStyles.font16DarkGreyMedium,
-      ),
-    );
-  }
-
-  DataCell _buildEditMenuButton(String id) {
-    return DataCell(
-      widget.actionButton(id),
-    );
-  }
 }

--- a/lib/core/widgets/custom_table_data_source.dart
+++ b/lib/core/widgets/custom_table_data_source.dart
@@ -1,0 +1,80 @@
+import 'package:el_sharq_clinic/core/theming/app_colors.dart';
+import 'package:el_sharq_clinic/core/theming/app_text_styles.dart';
+import 'package:flutter/material.dart';
+
+class CustomTableDataSource extends DataTableSource {
+  final List data;
+  final int columnsCount;
+  final Widget Function(String id) actionBuilder;
+  final int tappableCellIndex;
+  final Function(int index, bool selected) onSelectionChanged;
+  final Function(String id) onTappableCellTap;
+  final List<bool> selectedRows;
+
+  CustomTableDataSource({
+    required this.columnsCount,
+    required this.data,
+    required this.actionBuilder,
+    required this.tappableCellIndex,
+    required this.onSelectionChanged,
+    required this.onTappableCellTap,
+    required this.selectedRows,
+  });
+
+  @override
+  DataRow? getRow(int index) {
+    return DataRow(
+      // color: WidgetStateProperty.resolveWith((states) {
+      //   return AppColors.white;
+      // }),
+      onSelectChanged: (bool? selected) {
+        onSelectionChanged(index, selected ?? false);
+      },
+      selected: selectedRows[index],
+      cells: List.generate(columnsCount, (cellIndex) {
+        if (cellIndex == columnsCount - 1) {
+          return _buildEditMenuButton(data[index][0]);
+        }
+        if (cellIndex == tappableCellIndex) {
+          return _buildTappableCell(index, cellIndex, onTappableCellTap);
+        }
+        return DataCell(
+          Text(
+            data[index][cellIndex],
+            style: AppTextStyles.font16DarkGreyMedium,
+          ),
+        );
+      }),
+    );
+  }
+
+  DataCell _buildTappableCell(
+      int index, int cellIndex, Function(String)? onCellSelected) {
+    return DataCell(
+      onTap: () {
+        if (onCellSelected != null) {
+          onCellSelected(data[index][0]);
+        }
+      },
+      Text(
+        data[index][cellIndex],
+        style: AppTextStyles.font16DarkGreyMedium,
+      ),
+    );
+  }
+
+  DataCell _buildEditMenuButton(String id) {
+    return DataCell(
+      actionBuilder(id),
+    );
+  }
+
+  @override
+  int get rowCount => data.length;
+
+  @override
+  bool get isRowCountApproximate => false;
+
+  @override
+  int get selectedRowCount => 0;
+}

--- a/lib/core/widgets/section_details_container.dart
+++ b/lib/core/widgets/section_details_container.dart
@@ -2,10 +2,17 @@ import 'package:el_sharq_clinic/core/theming/app_colors.dart';
 import 'package:flutter/material.dart';
 
 class SectionDetailsContainer extends StatelessWidget {
-  const SectionDetailsContainer({super.key, required this.child, this.padding});
+  const SectionDetailsContainer(
+      {super.key,
+      required this.child,
+      this.padding,
+      this.color,
+      this.borderRadius});
 
   final Widget child;
   final EdgeInsets? padding;
+  final Color? color;
+  final double? borderRadius;
 
   @override
   Widget build(BuildContext context) {
@@ -19,8 +26,8 @@ class SectionDetailsContainer extends StatelessWidget {
 
   BoxDecoration _buildContainerDecoration() {
     return BoxDecoration(
-      borderRadius: BorderRadius.circular(10),
-      color: AppColors.white,
+      borderRadius: BorderRadius.circular(borderRadius ?? 0),
+      color: color ?? AppColors.white,
     );
   }
 }

--- a/lib/features/cases/data/local/models/case_history_model.dart
+++ b/lib/features/cases/data/local/models/case_history_model.dart
@@ -43,22 +43,22 @@ class CaseHistoryModel {
     );
   }
 
-  factory CaseHistoryModel.fromFirestore(
-      String id, DocumentSnapshot<Map<String, dynamic>> snapshot) {
+  factory CaseHistoryModel.fromFirestore(QueryDocumentSnapshot<Object?> doc) {
     return CaseHistoryModel(
-      id: id,
-      ownerName: snapshot['ownerName'],
-      phone: snapshot['phone'],
-      petName: snapshot['petName'],
-      petType: snapshot['petType'],
-      date: snapshot['date'],
-      time: snapshot['time'],
-      petReport: snapshot['petReport'],
+      id: doc.id,
+      ownerName: doc['ownerName'],
+      phone: doc['phone'],
+      petName: doc['petName'],
+      petType: doc['petType'],
+      date: doc['date'],
+      time: doc['time'],
+      petReport: doc['petReport'],
     );
   }
 
   Map<String, dynamic> toFirestore() {
     return {
+      'id': id ?? '',
       'ownerName': ownerName,
       'phone': phone,
       'petName': petName,

--- a/lib/features/cases/data/local/repos/case_history_repo.dart
+++ b/lib/features/cases/data/local/repos/case_history_repo.dart
@@ -6,8 +6,15 @@ class CaseHistoryRepo {
 
   CaseHistoryRepo(this._caseHistoryFirebaseServices);
 
-  Future<List<CaseHistoryModel>> getAllCases(int clinicIndex) async {
-    return await _caseHistoryFirebaseServices.getAllCaseHistories(clinicIndex);
+  Future<List<CaseHistoryModel>> getAllCases(
+      int clinicIndex, String? lastCaseId) async {
+    return await _caseHistoryFirebaseServices.getAllCaseHistories(
+        clinicIndex: clinicIndex, lastCaseId: lastCaseId);
+  }
+
+  Future<String?> getFirstCaseId(int clinicIndex, bool descendingOrder) async {
+    return await _caseHistoryFirebaseServices.getFirstCaseId(
+        clinicIndex: clinicIndex, descendingOrder: descendingOrder);
   }
 
   Future<bool> addNewCase(CaseHistoryModel appointment, int clinicIndex) async {

--- a/lib/features/cases/logic/cubit/case_history_state.dart
+++ b/lib/features/cases/logic/cubit/case_history_state.dart
@@ -15,7 +15,7 @@ final class CaseHistoryLoading extends CaseHistoryState {
 }
 
 final class CaseHistorySuccess extends CaseHistoryState {
-  final List<CaseHistoryModel> cases;
+  final List<CaseHistoryModel?> cases;
 
   CaseHistorySuccess({required this.cases});
 
@@ -47,7 +47,7 @@ final class CaseHistoryError extends CaseHistoryState {
   }
 }
 
-// New CaseHistory
+// CaseHistory
 final class NewCaseHistoryInvalid extends CaseHistoryState {
   final String? title;
   final String errorMessage;
@@ -86,19 +86,21 @@ final class NewCaseHistoryLoading extends CaseHistoryState {
 final class NewCaseHistorySuccess extends CaseHistoryState {
   @override
   void takeAction(BuildContext context) {
+    // Hide loading dialog
     context.pop();
-
+    // Hide side sheet
     context.pop();
 
     showDialog(
       context: context,
+      barrierDismissible: false,
       builder: (ctx) => const AppDialog(
         title: 'Success',
         content: 'New case created successfully',
         dialogType: DialogType.success,
       ),
     );
-
+    // Hide success dialog after 2 seconds
     Future.delayed(const Duration(seconds: 2), () => context.pop());
   }
 }
@@ -127,7 +129,6 @@ final class NewCaseHistoryFailure extends CaseHistoryState {
   }
 }
 
-// Update CaseHistory
 final class UpdateCaseHistorySuccess extends CaseHistoryState {
   @override
   void takeAction(BuildContext context) {
@@ -137,6 +138,7 @@ final class UpdateCaseHistorySuccess extends CaseHistoryState {
 
     showDialog(
       context: context,
+      barrierDismissible: false,
       builder: (ctx) => const AppDialog(
         title: 'Success',
         content: 'Case updated successfully',

--- a/lib/features/cases/ui/case_history_section.dart
+++ b/lib/features/cases/ui/case_history_section.dart
@@ -16,9 +16,6 @@ class CaseHistorySection extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     context.read<CaseHistoryCubit>().setupSectionData(authData);
-
-    // context.read<CaseHistoryCubit>().setAuthData(authData);
-    // context.read<CaseHistoryCubit>().getAllCases();
     return SectionContainer(
       title: 'Case History',
       actions: const [

--- a/lib/features/cases/ui/widgets/case_history_action_button.dart
+++ b/lib/features/cases/ui/widgets/case_history_action_button.dart
@@ -1,3 +1,4 @@
+import 'package:el_sharq_clinic/core/helpers/extensions.dart';
 import 'package:el_sharq_clinic/core/theming/app_text_styles.dart';
 import 'package:el_sharq_clinic/core/widgets/app_alert_dialog.dart';
 import 'package:el_sharq_clinic/features/cases/logic/cubit/case_history_cubit.dart';
@@ -16,14 +17,14 @@ class CaseHistoryTableActionButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return PopupMenuButton(
-      itemBuilder: (context) {
+      itemBuilder: (ctx) {
         return [
           PopupMenuItem(
             value: 'Edit',
             onTap: () {
               final caseHistoryModel =
                   context.read<CaseHistoryCubit>().getCaseHistoryById(id);
-              showCaseHistoryideSheet(context, 'Edit Case',
+              showCaseSheet(context, 'Edit Case',
                   caseHistoryModel: caseHistoryModel);
             },
             child: const Text(
@@ -35,13 +36,17 @@ class CaseHistoryTableActionButton extends StatelessWidget {
             value: 'Delete',
             onTap: () {
               showDialog(
-                context: context,
-                builder: (context) => AppAlertDialog(
+                context: ctx,
+                builder: (_) => AppAlertDialog(
                   alertMessage: 'Are you sure you want to delete this case?\n'
                       'This action cannot be undone.',
-                  onConfirm: () =>
-                      context.read<CaseHistoryCubit>().deleteCase(id),
-                  onCancel: () {},
+                  onConfirm: () {
+                    context.read<CaseHistoryCubit>().deleteCase(id);
+                    ctx.pop();
+                  },
+                  onCancel: () {
+                    ctx.pop();
+                  },
                 ),
               );
             },

--- a/lib/features/cases/ui/widgets/case_history_side_sheet.dart
+++ b/lib/features/cases/ui/widgets/case_history_side_sheet.dart
@@ -12,7 +12,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 
-Future<void> showCaseHistoryideSheet(BuildContext context, String title,
+Future<void> showCaseSheet(BuildContext context, String title,
     {CaseHistoryModel? caseHistoryModel, bool editable = true}) async {
   final bool newCase = caseHistoryModel == null;
   final CaseHistoryCubit caseHistoryCubit = context.read<CaseHistoryCubit>();

--- a/lib/features/cases/ui/widgets/main_action_button.dart
+++ b/lib/features/cases/ui/widgets/main_action_button.dart
@@ -1,3 +1,4 @@
+import 'package:el_sharq_clinic/core/helpers/extensions.dart';
 import 'package:el_sharq_clinic/core/theming/app_colors.dart';
 import 'package:el_sharq_clinic/core/widgets/app_alert_dialog.dart';
 import 'package:el_sharq_clinic/core/widgets/app_text_button.dart';
@@ -13,7 +14,7 @@ class MainActionButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return ListenableBuilder(
       listenable: context.read<CaseHistoryCubit>().showDeleteButtonNotifier,
-      builder: (context, child) => AnimatedSwitcher(
+      builder: (ctx, child) => AnimatedSwitcher(
         duration: const Duration(milliseconds: 500),
         child: context.read<CaseHistoryCubit>().showDeleteButtonNotifier.value
             ? _buildDeleteCaseButton(context)
@@ -27,7 +28,7 @@ class MainActionButton extends StatelessWidget {
       key: const ValueKey('new_case_button'),
       text: 'New Case',
       icon: Icons.book_outlined,
-      onPressed: () => showCaseHistoryideSheet(context, 'New Case'),
+      onPressed: () => showCaseSheet(context, 'New Case'),
       width: 200,
     );
   }
@@ -48,11 +49,16 @@ class MainActionButton extends StatelessWidget {
   Future<dynamic> _showDeleteDialog(BuildContext context) {
     return showDialog(
       context: context,
-      builder: (context) => AppAlertDialog(
+      builder: (ctx) => AppAlertDialog(
         alertMessage: 'Are you sure you want to delete these cases?\n'
             'This action cannot be undone.',
-        onConfirm: () => context.read<CaseHistoryCubit>().deleteSelectedCases(),
-        onCancel: () {},
+        onConfirm: () {
+          context.read<CaseHistoryCubit>().deleteSelectedCases();
+          context.pop();
+        },
+        onCancel: () {
+          ctx.pop();
+        },
       ),
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,7 @@ environment:
 dependencies:
   cloud_firestore: ^5.2.1
   cupertino_icons: ^1.0.8
+  data_table_2: ^2.5.15
   firebase_core: ^3.3.0
   firedart: ^0.9.8
   flutter:
@@ -38,9 +39,8 @@ dependencies:
   flutter_screenutil: ^5.9.3
   get_it: ^7.7.0
   screen_retriever: ^0.1.9
-  window_manager: ^0.4.0
-  data_table_2: ^2.5.15
   side_sheet: ^1.0.4
+  window_manager: ^0.4.0
 
 dev_dependencies:
   flutter_lints: ^4.0.0


### PR DESCRIPTION
- Refactored the `onConfirm` and `onCancel` params in `AppAlertDialog` from `VoidCallback` to `void Function()`.
- Customized the `CustomTable` to fit the app requirements.
- Added `CustomTableDataSource` to be the data source of app table.
- Implemented the logic of pagination in `CaseHistoryFirebaseServices` `CaseHistoryRepo` and `CaseHistoryCubit`.
- Refactored the new case button to be the deletion process button when the user select items from the table checkbox.
- Converted `CaseHistoryBody` to stateful widget to handle table items selection.

**Cases Section Preview**
![image](https://github.com/user-attachments/assets/479129ef-3992-40b3-a938-48df75fb2f32)
