### PR TITLE
Finish Owners Section UI Logic✅

### DIFF
--- a/lib/core/di/dependency_injection.dart
+++ b/lib/core/di/dependency_injection.dart
@@ -6,6 +6,7 @@ import 'package:el_sharq_clinic/features/cases/logic/cubit/case_history_cubit.da
 import 'package:el_sharq_clinic/features/auth/logic/cubit/auth_cubit.dart';
 import 'package:el_sharq_clinic/features/auth/data/local/repos/auth_repo.dart';
 import 'package:el_sharq_clinic/features/auth/data/remote/auth_firebase_services.dart';
+import 'package:el_sharq_clinic/features/owners/logic/cubit/owners_cubit.dart';
 import 'package:get_it/get_it.dart';
 
 GetIt getIt = GetIt.instance;
@@ -23,6 +24,7 @@ void setupGetIt() {
   // Cubits
   getIt.registerFactory<AuthCubit>(() => AuthCubit(getIt()));
   getIt.registerFactory<CaseHistoryCubit>(() => CaseHistoryCubit(getIt()));
+  getIt.registerFactory<OwnersCubit>(() => OwnersCubit());
 
   // Repos
   getIt.registerLazySingleton<AuthRepo>(() => AuthRepo(getIt()));

--- a/lib/core/helpers/constants.dart
+++ b/lib/core/helpers/constants.dart
@@ -47,4 +47,14 @@ abstract class AppConstant {
     'Number of Pets',
     ''
   ];
+
+  // Pets
+  static const String petReportScheme = """Diagnosis:
+Temp:
+Unique signs: 
+R.R:
+H.R:
+B.W: ..... kg 
+Vaccinations:
+Treatment:""";
 }

--- a/lib/core/widgets/app_text_field.dart
+++ b/lib/core/widgets/app_text_field.dart
@@ -18,6 +18,8 @@ class AppTextField extends StatelessWidget {
     this.suffixIcon,
     this.enabled,
     this.readOnly,
+    this.validator,
+    this.initialValue,
   });
 
   final TextEditingController? controller;
@@ -32,6 +34,8 @@ class AppTextField extends StatelessWidget {
   final Widget? suffixIcon;
   final bool? enabled;
   final bool? readOnly;
+  final String? Function(String?)? validator;
+  final String? initialValue;
 
   @override
   Widget build(BuildContext context) {
@@ -54,9 +58,11 @@ class AppTextField extends StatelessWidget {
     );
   }
 
-  TextField _buildTextFieldWithInsideHint(String? hint) {
-    return TextField(
+  TextFormField _buildTextFieldWithInsideHint(String? hint) {
+    return TextFormField(
       controller: controller,
+      validator: validator,
+      initialValue: initialValue,
       style: AppTextStyles.font20DarkGreyMedium,
       obscureText: isObscured ?? false,
       cursorHeight: 30.h,
@@ -81,7 +87,7 @@ class AppTextField extends StatelessWidget {
           borderSide: const BorderSide(color: AppColors.darkGrey),
         ),
         constraints: BoxConstraints(
-          maxHeight: height ?? 60.h,
+          maxHeight: height ?? double.infinity,
           maxWidth: width ?? 300.w,
         ),
       ),

--- a/lib/core/widgets/fields_row.dart
+++ b/lib/core/widgets/fields_row.dart
@@ -3,6 +3,11 @@ import 'package:el_sharq_clinic/core/widgets/app_text_field.dart';
 import 'package:flutter/material.dart';
 
 class FieldsRow extends StatelessWidget {
+  /// A row of fields.
+  ///
+  /// This widget represents a row of fields that can be used in forms or data entry screens.
+  /// It is a stateless widget, meaning it does not hold any mutable state.
+  /// Use this widget to display a row of two fields in your application.
   const FieldsRow({
     super.key,
     required this.fields,
@@ -13,16 +18,25 @@ class FieldsRow extends StatelessWidget {
     this.secondSuffixIcon,
     this.readOnly,
     this.isMultiline,
+    this.validations = const [true, true],
   });
 
+  /// Fields[0] for first field, fields[1] for second field
   final List<String> fields;
   final TextEditingController? firstController;
   final TextEditingController? secondController;
+
+  /// FirstSuffixIcon is an icon for first field
   final Widget? firstSuffixIcon;
+
+  /// SecondSuffixIcon is an icon for second field
   final Widget? secondSuffixIcon;
   final bool? enabled;
   final bool? readOnly;
   final bool? isMultiline;
+
+  /// validations[0] for first field, validations[1] for second field
+  final List<bool>? validations;
 
   @override
   Widget build(BuildContext context) {
@@ -30,6 +44,14 @@ class FieldsRow extends StatelessWidget {
       children: [
         Expanded(
           child: AppTextField(
+            validator: validations!.first
+                ? (value) {
+                    if (value!.trim().isEmpty) {
+                      return 'Please enter a ${fields.first}';
+                    }
+                    return null;
+                  }
+                : null,
             controller: firstController,
             hint: fields.first,
             suffixIcon: firstSuffixIcon,
@@ -42,6 +64,14 @@ class FieldsRow extends StatelessWidget {
         horizontalSpace(50),
         Expanded(
           child: AppTextField(
+            validator: validations!.last
+                ? (value) {
+                    if (value!.trim().isEmpty) {
+                      return 'Please enter a ${fields.last}';
+                    }
+                    return null;
+                  }
+                : null,
             controller: secondController,
             hint: fields.last,
             suffixIcon: secondSuffixIcon,

--- a/lib/core/widgets/section_search_bar.dart
+++ b/lib/core/widgets/section_search_bar.dart
@@ -25,7 +25,7 @@ class SectionSearchBar extends StatelessWidget {
         controller: controller,
         onChanged: onChanged,
         textAlignVertical: TextAlignVertical.center,
-        cursorHeight: 5.h,
+        cursorHeight: 25.h,
         style: AppTextStyles.font20DarkGreyMedium,
         decoration: _buildInputDecoration(),
       ),

--- a/lib/features/cases/logic/cubit/case_history_cubit.dart
+++ b/lib/features/cases/logic/cubit/case_history_cubit.dart
@@ -1,3 +1,4 @@
+import 'package:el_sharq_clinic/core/helpers/constants.dart';
 import 'package:el_sharq_clinic/core/helpers/extensions.dart';
 import 'package:el_sharq_clinic/core/models/auth_data_model.dart';
 import 'package:el_sharq_clinic/core/widgets/app_dialog.dart';
@@ -251,14 +252,7 @@ class CaseHistoryCubit extends Cubit<CaseHistoryState> {
   }
 
   String get _getPetReportScheme {
-    return """Diagnosis:
-Temp:
-Unique signs: 
-R.R:
-H.R:
-B.W: ..... kg 
-Vaccinations:
-Treatment:""";
+    return AppConstant.petReportScheme;
   }
 
   String get _getReportFirebaseText {

--- a/lib/features/home/ui/home_layout.dart
+++ b/lib/features/home/ui/home_layout.dart
@@ -6,6 +6,7 @@ import 'package:el_sharq_clinic/features/cases/ui/case_history_section.dart';
 import 'package:el_sharq_clinic/features/dashboard/ui/dashboard_section.dart';
 import 'package:el_sharq_clinic/features/home/ui/widgets/custom_app_bar.dart';
 import 'package:el_sharq_clinic/features/home/ui/widgets/custom_drawer.dart';
+import 'package:el_sharq_clinic/features/owners/logic/cubit/owners_cubit.dart';
 import 'package:el_sharq_clinic/features/owners/ui/owners_section.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -62,8 +63,9 @@ class _HomeLayoutState extends State<HomeLayout> {
             create: (context) => getIt<CaseHistoryCubit>(),
             child: CaseHistorySection(authData: widget.authData),
           ),
-      (context) => OwnersSection(
-            authData: widget.authData,
+      (context) => BlocProvider<OwnersCubit>(
+            create: (context) => getIt<OwnersCubit>(),
+            child: OwnersSection(authData: widget.authData),
           ),
       // const Text('Pet Owners'),
       // const Text('Services'),

--- a/lib/features/owners/logic/cubit/owners_cubit.dart
+++ b/lib/features/owners/logic/cubit/owners_cubit.dart
@@ -1,0 +1,53 @@
+import 'dart:developer';
+
+import 'package:bloc/bloc.dart';
+import 'package:flutter/material.dart';
+
+part 'owners_state.dart';
+
+class OwnersCubit extends Cubit<OwnersState> {
+  OwnersCubit() : super(OwnersInitial());
+
+  ValueNotifier<int> numberOfPetsNotifier = ValueNotifier(1);
+  GlobalKey<FormState> ownerFormKey = GlobalKey<FormState>();
+  List<GlobalKey<FormState>> petFormsKeys = [GlobalKey<FormState>()];
+
+  void setupNewSheet() {
+    numberOfPetsNotifier = ValueNotifier<int>(1);
+  }
+
+  void incrementPets() {
+    numberOfPetsNotifier.value++;
+    petFormsKeys.add(GlobalKey<FormState>());
+    emit(OwnersPetsChanged(numberOfPetsNotifier.value));
+  }
+
+  void decrementPets(int index) {
+    numberOfPetsNotifier.value--;
+    petFormsKeys.removeAt(index);
+    emit(OwnersPetsChanged(numberOfPetsNotifier.value));
+  }
+
+  bool _validateForms() {
+    bool isValid = true;
+    // Validate owner form
+    if (!ownerFormKey.currentState!.validate()) {
+      isValid = false;
+    }
+    // Validate pet forms
+    for (final formKey in petFormsKeys) {
+      if (!formKey.currentState!.validate()) {
+        isValid = false;
+      }
+    }
+    return isValid;
+  }
+
+  void validateThenSave() {
+    if (_validateForms()) {
+      log('All forms are valid');
+    } else {
+      log('Some forms are invalid');
+    }
+  }
+}

--- a/lib/features/owners/logic/cubit/owners_state.dart
+++ b/lib/features/owners/logic/cubit/owners_state.dart
@@ -1,0 +1,11 @@
+part of 'owners_cubit.dart';
+
+abstract class OwnersState {}
+
+final class OwnersInitial extends OwnersState {}
+
+final class OwnersPetsChanged extends OwnersState {
+  final int numberOfPets;
+
+  OwnersPetsChanged(this.numberOfPets);
+}

--- a/lib/features/owners/ui/widgets/owners_body.dart
+++ b/lib/features/owners/ui/widgets/owners_body.dart
@@ -4,6 +4,7 @@ import 'package:el_sharq_clinic/core/helpers/constants.dart';
 import 'package:el_sharq_clinic/core/widgets/custom_table.dart';
 import 'package:el_sharq_clinic/core/widgets/custom_table_data_source.dart';
 import 'package:el_sharq_clinic/features/cases/ui/widgets/case_history_action_button.dart';
+import 'package:el_sharq_clinic/features/owners/ui/widgets/owners_row_action_button.dart';
 import 'package:flutter/material.dart';
 
 class OwnersBody extends StatelessWidget {
@@ -13,24 +14,24 @@ class OwnersBody extends StatelessWidget {
   Widget build(BuildContext context) {
     return CustomTable(
       onPageChanged: (firstIndex) {
-        // context.read<CaseHistoryCubit>().getNextPage(firstIndex);
+        // context.read<OwnersCubitCubit>().getNextPage(firstIndex);
       },
       fields: AppConstant.ownersTableHeaders,
       dataSource: CustomTableDataSource(
         columnsCount: AppConstant.casesTableHeaders.length,
         data: _getRows(context),
-        actionBuilder: (id) => CaseHistoryTableActionButton(
+        actionBuilder: (id) => OwnersRowActionButton(
           id: id,
         ),
         tappableCellIndex: 0,
         onSelectionChanged: (index, selected) {
           // setState(() {
-          //   context.read<CaseHistoryCubit>().onMultiSelection(index, selected);
+          //   context.read<OwnersCubitCubit>().onMultiSelection(index, selected);
           // });
         },
         onTappableCellTap: (id) => log('Tapped on case id: $id'),
         selectedRows: [],
-        // selectedRows: context.read<CaseHistoryCubit>().selectedRows,
+        // selectedRows: context.read<OwnersCubitCubit>().selectedRows,
       ),
     );
   }

--- a/lib/features/owners/ui/widgets/owners_row_action_button.dart
+++ b/lib/features/owners/ui/widgets/owners_row_action_button.dart
@@ -1,0 +1,61 @@
+import 'package:el_sharq_clinic/core/helpers/extensions.dart';
+import 'package:el_sharq_clinic/core/theming/app_text_styles.dart';
+import 'package:el_sharq_clinic/core/widgets/app_alert_dialog.dart';
+import 'package:flutter/material.dart';
+
+class OwnersRowActionButton extends StatelessWidget {
+  const OwnersRowActionButton({
+    super.key,
+    required this.id,
+  });
+
+  final String id;
+
+  @override
+  Widget build(BuildContext context) {
+    return PopupMenuButton(
+      itemBuilder: (ctx) {
+        return [
+          PopupMenuItem(
+            value: 'Edit',
+            onTap: () {},
+            child: const Text(
+              'Edit',
+              style: AppTextStyles.font14DarkGreyMedium,
+            ),
+          ),
+          PopupMenuItem(
+            value: 'Add Pet',
+            onTap: () {},
+            child: const Text(
+              'Edit',
+              style: AppTextStyles.font14DarkGreyMedium,
+            ),
+          ),
+          PopupMenuItem(
+            value: 'Delete',
+            onTap: () {
+              showDialog(
+                context: ctx,
+                builder: (_) => AppAlertDialog(
+                  alertMessage: 'Are you sure you want to delete this case?\n'
+                      'This action cannot be undone.',
+                  onConfirm: () {
+                    ctx.pop();
+                  },
+                  onCancel: () {
+                    ctx.pop();
+                  },
+                ),
+              );
+            },
+            child: const Text(
+              'Delete',
+              style: AppTextStyles.font14DarkGreyMedium,
+            ),
+          ),
+        ];
+      },
+    );
+  }
+}

--- a/lib/features/owners/ui/widgets/owners_side_sheet.dart
+++ b/lib/features/owners/ui/widgets/owners_side_sheet.dart
@@ -1,21 +1,22 @@
 import 'package:el_sharq_clinic/core/helpers/spacing.dart';
-import 'package:el_sharq_clinic/core/theming/app_colors.dart';
-import 'package:el_sharq_clinic/core/theming/app_text_styles.dart';
 import 'package:el_sharq_clinic/core/widgets/app_text_button.dart';
 import 'package:el_sharq_clinic/core/widgets/app_text_field.dart';
 import 'package:el_sharq_clinic/core/widgets/custom_side_sheet.dart';
-import 'package:el_sharq_clinic/core/widgets/fields_row.dart';
 import 'package:el_sharq_clinic/core/widgets/section_title.dart';
 import 'package:el_sharq_clinic/features/owners/data/local/models/owner_model.dart';
+import 'package:el_sharq_clinic/features/owners/logic/cubit/owners_cubit.dart';
 import 'package:el_sharq_clinic/features/owners/ui/widgets/side_sheet_owner_container.dart';
+import 'package:el_sharq_clinic/features/owners/ui/widgets/side_sheet_pets_column.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 
 Future<void> showOwnerSheet(BuildContext context, String title,
     {OwnerModel? ownerModel, bool editable = true}) async {
   final bool newOwner = ownerModel == null;
-  // final OwnersCubit OwnersCubit = context.read<OwnersCubit>();
-  // newCase
+  final OwnersCubit ownersCubit = context.read<OwnersCubit>();
+  ownersCubit.setupNewSheet();
+  // newOwner
   //     ? OwnersCubit.setupNewModeControllers()
   //     : OwnersCubit.setupShowModeControllers(caseHistoryModel);
 
@@ -25,74 +26,19 @@ Future<void> showOwnerSheet(BuildContext context, String title,
       children: [
         SectionTitle(title: title),
         verticalSpace(50),
-        if (newOwner) _buildAddPetButton(context),
+        if (newOwner) _buildAddPetButton(context, ownersCubit),
         if (!newOwner) _buildOwnerId(context),
         verticalSpace(50),
         SideSheetOwnerContainer(
           editable: editable,
+          ownerFormKey: ownersCubit.ownerFormKey,
         ),
         verticalSpace(50),
-        Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              'Pet 1',
-              style: AppTextStyles.font16DarkGreyMedium
-                  .copyWith(color: AppColors.darkGrey.withOpacity(0.5)),
-            ),
-            Container(
-              padding: const EdgeInsets.all(20),
-              decoration: BoxDecoration(
-                border: Border.all(color: Colors.grey),
-                borderRadius: BorderRadius.circular(10),
-              ),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  AppTextField(
-                    hint: 'Name',
-                    enabled: editable,
-                    width: double.infinity,
-                    insideHint: false,
-                  ),
-                  verticalSpace(15),
-                  FieldsRow(
-                    fields: const [
-                      'Gender',
-                      'Type',
-                    ],
-                    enabled: editable,
-                  ),
-                  verticalSpace(15),
-                  FieldsRow(
-                    fields: const [
-                      'Age',
-                      'Breed',
-                    ],
-                    enabled: editable,
-                  ),
-                  verticalSpace(15),
-                  FieldsRow(
-                    fields: const [
-                      'Vaccination',
-                      'Treatments',
-                    ],
-                    enabled: editable,
-                    isMultiline: true,
-                  ),
-                  verticalSpace(15),
-                  AppTextField(
-                    hint: 'Pet Report',
-                    enabled: editable,
-                    width: double.infinity,
-                    height: 150,
-                    isMultiline: true,
-                    insideHint: false,
-                  ),
-                ],
-              ),
-            ),
-          ],
+        SideSheetPetsColumn(
+          editable: editable,
+          petsNumberNotifier: ownersCubit.numberOfPetsNotifier,
+          petFormsKeys: ownersCubit.petFormsKeys,
+          onDecrementPets: (index) => ownersCubit.decrementPets(index),
         ),
         verticalSpace(100),
         _buildActionIfNeeded(context, newOwner, editable),
@@ -101,12 +47,12 @@ Future<void> showOwnerSheet(BuildContext context, String title,
   );
 }
 
-_buildAddPetButton(BuildContext context) {
+_buildAddPetButton(BuildContext context, OwnersCubit ownersCubit) {
   return AppTextButton(
     text: 'Add Pet',
     width: MediaQuery.sizeOf(context).width,
     height: 70.h,
-    onPressed: () {},
+    onPressed: () => ownersCubit.incrementPets(),
   );
 }
 
@@ -120,7 +66,7 @@ _buildActionIfNeeded(BuildContext context, bool newCase, bool editMode) {
 }
 
 AppTextField _buildOwnerId(BuildContext context) {
-  return AppTextField(
+  return const AppTextField(
     hint: 'Owner ID',
     enabled: false,
     width: double.infinity,
@@ -133,7 +79,9 @@ AppTextButton _buildNewAction(BuildContext context) {
     text: 'Save Owner',
     width: MediaQuery.sizeOf(context).width,
     height: 70.h,
-    onPressed: () {},
+    onPressed: () {
+      context.read<OwnersCubit>().validateThenSave();
+    },
   );
 }
 

--- a/lib/features/owners/ui/widgets/side_sheet_owner_container.dart
+++ b/lib/features/owners/ui/widgets/side_sheet_owner_container.dart
@@ -7,9 +7,11 @@ class SideSheetOwnerContainer extends StatelessWidget {
   const SideSheetOwnerContainer({
     super.key,
     required this.editable,
+    required this.ownerFormKey,
   });
 
   final bool editable;
+  final GlobalKey<FormState> ownerFormKey;
 
   @override
   Widget build(BuildContext context) {
@@ -27,14 +29,16 @@ class SideSheetOwnerContainer extends StatelessWidget {
             border: Border.all(color: Colors.grey),
             borderRadius: BorderRadius.circular(10),
           ),
-          child: FieldsRow(
-            fields: const [
-              'Name',
-              'Phone',
-            ],
-            // firstController: caseHistoryCubit.ownerNameController,
-            // secondController: caseHistoryCubit.petTypeController,
-            enabled: editable,
+          child: Form(
+            key: ownerFormKey,
+            child: FieldsRow(
+              fields: const [
+                'Name',
+                'Phone',
+              ],
+              validations: const [true, true],
+              enabled: editable,
+            ),
           ),
         ),
       ],

--- a/lib/features/owners/ui/widgets/side_sheet_pet_container.dart
+++ b/lib/features/owners/ui/widgets/side_sheet_pet_container.dart
@@ -1,0 +1,99 @@
+import 'package:el_sharq_clinic/core/helpers/constants.dart';
+import 'package:el_sharq_clinic/core/helpers/spacing.dart';
+import 'package:el_sharq_clinic/core/theming/app_colors.dart';
+import 'package:el_sharq_clinic/core/theming/app_text_styles.dart';
+import 'package:el_sharq_clinic/core/widgets/app_text_field.dart';
+import 'package:el_sharq_clinic/core/widgets/fields_row.dart';
+import 'package:flutter/material.dart';
+
+class SideSheetPetContainer extends StatelessWidget {
+  const SideSheetPetContainer({
+    super.key,
+    required this.editable,
+    required this.index,
+    required this.petFormKey,
+  });
+
+  final int index;
+  final bool editable;
+  final GlobalKey<FormState> petFormKey;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Pet $index',
+          style: AppTextStyles.font16DarkGreyMedium
+              .copyWith(color: AppColors.darkGrey.withOpacity(0.5)),
+        ),
+        Container(
+          padding: const EdgeInsets.all(20),
+          decoration: BoxDecoration(
+            border: Border.all(color: Colors.grey),
+            borderRadius: BorderRadius.circular(10),
+          ),
+          child: Form(
+            key: petFormKey,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                AppTextField(
+                  hint: 'Name',
+                  validator: (value) {
+                    if (value!.trim().isEmpty) {
+                      return 'Please enter a Name';
+                    }
+                    return null;
+                  },
+                  enabled: editable,
+                  width: double.infinity,
+                  insideHint: false,
+                ),
+                verticalSpace(15),
+                FieldsRow(
+                  fields: const [
+                    'Gender',
+                    'Type',
+                  ],
+                  validations: const [false, false],
+                  enabled: editable,
+                ),
+                verticalSpace(15),
+                FieldsRow(
+                  fields: const [
+                    'Age',
+                    'Breed',
+                  ],
+                  validations: const [false, false],
+                  enabled: editable,
+                ),
+                verticalSpace(15),
+                FieldsRow(
+                  fields: const [
+                    'Vaccination',
+                    'Treatments',
+                  ],
+                  validations: const [false, false],
+                  enabled: editable,
+                  isMultiline: true,
+                ),
+                verticalSpace(15),
+                AppTextField(
+                  hint: 'Pet Report',
+                  initialValue: AppConstant.petReportScheme,
+                  enabled: editable,
+                  width: double.infinity,
+                  height: 150,
+                  isMultiline: true,
+                  insideHint: false,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/owners/ui/widgets/side_sheet_pets_column.dart
+++ b/lib/features/owners/ui/widgets/side_sheet_pets_column.dart
@@ -1,0 +1,66 @@
+import 'package:el_sharq_clinic/core/theming/app_colors.dart';
+import 'package:el_sharq_clinic/features/owners/ui/widgets/side_sheet_pet_container.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+class SideSheetPetsColumn extends StatelessWidget {
+  const SideSheetPetsColumn(
+      {super.key,
+      required this.editable,
+      required this.petsNumberNotifier,
+      required this.petFormsKeys,
+      required this.onDecrementPets});
+
+  final bool editable;
+  final ValueNotifier<int> petsNumberNotifier;
+  final List<GlobalKey<FormState>> petFormsKeys;
+  final void Function(int index) onDecrementPets;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: petsNumberNotifier,
+      builder: (ctx, state) {
+        return Column(
+          children: _getPets(petsNumberNotifier.value),
+        );
+      },
+    );
+  }
+
+  List<Widget> _getPets(int numberOfPets) {
+    return List.generate(
+      numberOfPets,
+      (index) => Padding(
+        padding: const EdgeInsets.only(bottom: 30),
+        child: Stack(
+          children: [
+            SideSheetPetContainer(
+              petFormKey: petFormsKeys[index],
+              index: index + 1,
+              editable: editable,
+            ),
+            if (index != 0) _buildRemoveButton(index),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Positioned _buildRemoveButton(int index) {
+    return Positioned(
+      top: 30.h,
+      right: 0,
+      child: IconButton(
+          hoverColor: Colors.transparent,
+          icon: const Icon(
+            Icons.cancel,
+            color: AppColors.red,
+            size: 30,
+          ),
+          onPressed: () {
+            onDecrementPets(index);
+          }),
+    );
+  }
+}


### PR DESCRIPTION
- Added `OwnersCubit` and `OwnersState`.
- Added `OwnersCubit` to DI file.
- Added `petReportScheme` constant in `constants` file.
- Refactored the `AppTextField` to be form field and added validator and initial value params to it.
- Added widget doc to `FieldsRow` widget.
- Wrapped the `OwnerSection` with `BlocProvider` in `HomeLayout` widget.
- Added `SideSheetPetsColumn` to hold one or more `SideSheetPetContainer` to be a pet item in the side sheet.
- Added `OwnersRowActionButton` to be the action button for each row in owners table.