### PR TITLE
Finish Adding Pet Owner & Its Pets✅

### DIFF
--- a/lib/core/di/dependency_injection.dart
+++ b/lib/core/di/dependency_injection.dart
@@ -6,6 +6,8 @@ import 'package:el_sharq_clinic/features/cases/logic/cubit/case_history_cubit.da
 import 'package:el_sharq_clinic/features/auth/logic/cubit/auth_cubit.dart';
 import 'package:el_sharq_clinic/features/auth/data/local/repos/auth_repo.dart';
 import 'package:el_sharq_clinic/features/auth/data/remote/auth_firebase_services.dart';
+import 'package:el_sharq_clinic/features/owners/data/local/repos/owners_repo.dart';
+import 'package:el_sharq_clinic/features/owners/data/local/repos/pets_repo.dart';
 import 'package:el_sharq_clinic/features/owners/logic/cubit/owners_cubit.dart';
 import 'package:get_it/get_it.dart';
 
@@ -24,9 +26,11 @@ void setupGetIt() {
   // Cubits
   getIt.registerFactory<AuthCubit>(() => AuthCubit(getIt()));
   getIt.registerFactory<CaseHistoryCubit>(() => CaseHistoryCubit(getIt()));
-  getIt.registerFactory<OwnersCubit>(() => OwnersCubit());
+  getIt.registerFactory<OwnersCubit>(() => OwnersCubit(getIt(), getIt()));
 
   // Repos
   getIt.registerLazySingleton<AuthRepo>(() => AuthRepo(getIt()));
   getIt.registerLazySingleton<CaseHistoryRepo>(() => CaseHistoryRepo(getIt()));
+  getIt.registerLazySingleton<OwnersRepo>(() => OwnersRepo(getIt()));
+  getIt.registerLazySingleton<PetsRepo>(() => PetsRepo(getIt()));
 }

--- a/lib/core/helpers/constants.dart
+++ b/lib/core/helpers/constants.dart
@@ -49,7 +49,7 @@ abstract class AppConstant {
   ];
 
   // Pets
-  static const String petReportScheme = """Diagnosis:
+  static const String petCaseReportScheme = """Diagnosis:
 Temp:
 Unique signs: 
 R.R:
@@ -57,4 +57,10 @@ H.R:
 B.W: ..... kg 
 Vaccinations:
 Treatment:""";
+
+  static const String petProfileReportScheme = """Diagnosis:
+Temp:
+Unique signs: 
+R.R:
+H.R:""";
 }

--- a/lib/core/helpers/extensions.dart
+++ b/lib/core/helpers/extensions.dart
@@ -23,4 +23,9 @@ extension StringExtensions on String {
   String toId(int idLength, {String prefix = ''}) {
     return prefix + this.padLeft(idLength, '0');
   }
+
+  String getNextId(int idLength, String prefix) {
+    final int id = int.parse(this.replaceAll(prefix, ''));
+    return (id + 1).toString().toId(idLength, prefix: prefix);
+  }
 }

--- a/lib/core/widgets/app_text_field.dart
+++ b/lib/core/widgets/app_text_field.dart
@@ -20,6 +20,7 @@ class AppTextField extends StatelessWidget {
     this.readOnly,
     this.validator,
     this.initialValue,
+    this.onSaved,
   });
 
   final TextEditingController? controller;
@@ -36,6 +37,7 @@ class AppTextField extends StatelessWidget {
   final bool? readOnly;
   final String? Function(String?)? validator;
   final String? initialValue;
+  final void Function(String? value)? onSaved;
 
   @override
   Widget build(BuildContext context) {
@@ -62,6 +64,7 @@ class AppTextField extends StatelessWidget {
     return TextFormField(
       controller: controller,
       validator: validator,
+      onSaved: onSaved,
       initialValue: initialValue,
       style: AppTextStyles.font20DarkGreyMedium,
       obscureText: isObscured ?? false,

--- a/lib/core/widgets/custom_table_data_source.dart
+++ b/lib/core/widgets/custom_table_data_source.dart
@@ -2,7 +2,7 @@ import 'package:el_sharq_clinic/core/theming/app_text_styles.dart';
 import 'package:flutter/material.dart';
 
 class CustomTableDataSource extends DataTableSource {
-  final List data;
+  final List<List> data;
   final int columnsCount;
   final Widget Function(String id) actionBuilder;
   final int tappableCellIndex;
@@ -29,6 +29,7 @@ class CustomTableDataSource extends DataTableSource {
       selected: selectedRows[index],
       cells: List.generate(columnsCount, (cellIndex) {
         if (cellIndex == columnsCount - 1) {
+          // Return the edit menu button with the id of the data row
           return _buildEditMenuButton(data[index][0]);
         }
         if (cellIndex == tappableCellIndex) {

--- a/lib/core/widgets/fields_row.dart
+++ b/lib/core/widgets/fields_row.dart
@@ -19,12 +19,17 @@ class FieldsRow extends StatelessWidget {
     this.readOnly,
     this.isMultiline,
     this.validations = const [true, true],
+    this.firstText,
+    this.secondText,
+    this.onSaved,
   });
 
   /// Fields[0] for first field, fields[1] for second field
   final List<String> fields;
   final TextEditingController? firstController;
   final TextEditingController? secondController;
+  final String? firstText;
+  final String? secondText;
 
   /// FirstSuffixIcon is an icon for first field
   final Widget? firstSuffixIcon;
@@ -38,12 +43,15 @@ class FieldsRow extends StatelessWidget {
   /// validations[0] for first field, validations[1] for second field
   final List<bool>? validations;
 
+  final void Function(String field, String? value)? onSaved;
+
   @override
   Widget build(BuildContext context) {
     return Row(
       children: [
         Expanded(
           child: AppTextField(
+            initialValue: firstText,
             validator: validations!.first
                 ? (value) {
                     if (value!.trim().isEmpty) {
@@ -52,6 +60,11 @@ class FieldsRow extends StatelessWidget {
                     return null;
                   }
                 : null,
+            onSaved: (value) {
+              if (onSaved != null) {
+                onSaved!(fields.first, value);
+              }
+            },
             controller: firstController,
             hint: fields.first,
             suffixIcon: firstSuffixIcon,
@@ -64,6 +77,7 @@ class FieldsRow extends StatelessWidget {
         horizontalSpace(50),
         Expanded(
           child: AppTextField(
+            initialValue: secondText,
             validator: validations!.last
                 ? (value) {
                     if (value!.trim().isEmpty) {
@@ -72,6 +86,11 @@ class FieldsRow extends StatelessWidget {
                     return null;
                   }
                 : null,
+            onSaved: (value) {
+              if (onSaved != null) {
+                onSaved!(fields.last, value);
+              }
+            },
             controller: secondController,
             hint: fields.last,
             suffixIcon: secondSuffixIcon,

--- a/lib/features/cases/data/local/models/case_history_model.dart
+++ b/lib/features/cases/data/local/models/case_history_model.dart
@@ -1,23 +1,23 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 class CaseHistoryModel {
-  final String? id;
+  final String id;
   final String ownerName;
-  final String phone;
-  final String petName;
-  final String petType;
+  final String? phone;
+  final String? petName;
+  final String? petType;
   final String date;
-  final String time;
+  final String? time;
   final String petReport;
 
   CaseHistoryModel({
-    this.id,
+    required this.id,
     required this.ownerName,
-    required this.phone,
-    required this.petName,
-    required this.petType,
+    this.phone,
+    this.petName,
+    this.petType,
     required this.date,
-    required this.time,
+    this.time,
     required this.petReport,
   });
 
@@ -44,41 +44,53 @@ class CaseHistoryModel {
   }
 
   factory CaseHistoryModel.fromFirestore(QueryDocumentSnapshot<Object?> doc) {
+    final data = doc.data() as Map<String, dynamic>;
     return CaseHistoryModel(
       id: doc.id,
-      ownerName: doc['ownerName'],
-      phone: doc['phone'],
-      petName: doc['petName'],
-      petType: doc['petType'],
-      date: doc['date'],
-      time: doc['time'],
-      petReport: doc['petReport'],
+      ownerName: data['ownerName'],
+      phone: data['phone'],
+      petName: data['petName'],
+      petType: data['petType'],
+      date: data['date'] ?? '',
+      time: data['time'],
+      petReport: data['petReport'] ?? '',
     );
   }
 
+  /// Create a map with the only non-null values
   Map<String, dynamic> toFirestore() {
-    return {
-      'id': id ?? '',
-      'ownerName': ownerName,
-      'phone': phone,
-      'petName': petName,
-      'petType': petType,
-      'date': date,
-      'time': time,
-      'petReport': petReport,
-    };
+    final Map<String, dynamic> map = toMap();
+    for (var key in map.keys.toList()) {
+      if (map[key].toString().trim().isEmpty || map[key] == null) {
+        map.remove(key);
+      }
+    }
+    return map;
   }
 
   List<String> toList() {
     return [
-      id ?? '',
+      id,
       ownerName,
-      phone,
-      petName,
+      phone ?? '',
+      petName ?? '',
       date,
-      petType,
-      time,
+      petType ?? '',
+      time ?? '',
       petReport,
     ];
+  }
+
+  Map<String, String?> toMap() {
+    return {
+      'id': id,
+      'ownerName': ownerName,
+      'phone': phone,
+      'petName': petName,
+      'date': date,
+      'petType': petType,
+      'time': time,
+      'petReport': petReport,
+    };
   }
 }

--- a/lib/features/cases/data/local/repos/case_history_repo.dart
+++ b/lib/features/cases/data/local/repos/case_history_repo.dart
@@ -2,13 +2,13 @@ import 'package:el_sharq_clinic/features/cases/data/local/models/case_history_mo
 import 'package:el_sharq_clinic/core/networking/firebase_services.dart';
 
 class CaseHistoryRepo {
-  final FirebaseServices _caseHistoryFirebaseServices;
+  final FirebaseServices _firebaseServices;
 
-  CaseHistoryRepo(this._caseHistoryFirebaseServices);
+  CaseHistoryRepo(this._firebaseServices);
 
   Future<List<CaseHistoryModel>> getAllCases(
       int clinicIndex, String? lastCaseId) async {
-    return await _caseHistoryFirebaseServices.getItems<CaseHistoryModel>(
+    return await _firebaseServices.getItems<CaseHistoryModel>(
       'cases',
       clinicIndex: clinicIndex,
       fromFirestore: CaseHistoryModel.fromFirestore,
@@ -17,7 +17,7 @@ class CaseHistoryRepo {
   }
 
   Future<String?> getFirstCaseId(int clinicIndex, bool descendingOrder) async {
-    return await _caseHistoryFirebaseServices.getFirstItemId(
+    return await _firebaseServices.getFirstItemId(
       'cases',
       clinicIndex: clinicIndex,
       descendingOrder: descendingOrder,
@@ -25,9 +25,10 @@ class CaseHistoryRepo {
   }
 
   Future<bool> addNewCase(CaseHistoryModel caseModel, int clinicIndex) async {
-    return await _caseHistoryFirebaseServices.addItem<CaseHistoryModel>(
+    return await _firebaseServices.addItem<CaseHistoryModel>(
       'cases',
       itemModel: caseModel,
+      id: caseModel.id,
       clinicIndex: clinicIndex,
       toFirestore: caseModel.toFirestore,
       idScheme: 'CSE',
@@ -35,17 +36,17 @@ class CaseHistoryRepo {
   }
 
   Future<bool> updateCase(CaseHistoryModel caseModel, int clinicIndex) async {
-    return await _caseHistoryFirebaseServices.updateItem<CaseHistoryModel>(
+    return await _firebaseServices.updateItem<CaseHistoryModel>(
       'cases',
       itemModel: caseModel,
       clinicIndex: clinicIndex,
       toFirestore: caseModel.toFirestore,
-      id: caseModel.id!,
+      id: caseModel.id,
     );
   }
 
   Future<bool> deleteCase(String caseId, int clinicIndex) async {
-    return await _caseHistoryFirebaseServices.deleteItem(
+    return await _firebaseServices.deleteItem(
       'cases',
       id: caseId,
       clinicIndex: clinicIndex,

--- a/lib/features/cases/ui/widgets/case_history_side_sheet.dart
+++ b/lib/features/cases/ui/widgets/case_history_side_sheet.dart
@@ -26,7 +26,7 @@ Future<void> showCaseSheet(BuildContext context, String title,
       children: [
         SectionTitle(title: title),
         verticalSpace(50),
-        if (!newCase) _buildCaseId(context),
+        if (!newCase) _buildCaseId(caseHistoryCubit.caseIdController),
         verticalSpace(50),
         FieldsRow(
           fields: const [
@@ -112,9 +112,9 @@ IconButton _buildTimeButton(
       ));
 }
 
-AppTextField _buildCaseId(BuildContext context) {
+AppTextField _buildCaseId(TextEditingController idController) {
   return AppTextField(
-    controller: context.read<CaseHistoryCubit>().caseIdController,
+    controller: idController,
     hint: 'Case ID',
     enabled: false,
     width: double.infinity,

--- a/lib/features/owners/data/local/models/owner_model.dart
+++ b/lib/features/owners/data/local/models/owner_model.dart
@@ -1,38 +1,71 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 class OwnerModel {
-  final String? id;
+  final String id;
   final String name;
   final String phone;
   final List<String> petsIds;
   String? registrationDate;
 
   OwnerModel({
-    this.id,
+    required this.id,
     required this.name,
     required this.phone,
     required this.petsIds,
     this.registrationDate,
-  }) {
-    registrationDate ??= DateTime.now().toIso8601String().substring(0, 10);
-  }
+  });
 
-  factory OwnerModel.fromFirestore(QueryDocumentSnapshot doc) {
+  factory OwnerModel.fromFirestore(QueryDocumentSnapshot<Object?> doc) {
     return OwnerModel(
       id: doc.id,
       name: doc['name'],
       phone: doc['phone'],
-      petsIds: doc['petsIds'],
+      petsIds: doc['petsIds'].cast<String>(),
       registrationDate: doc['registrationDate'],
+    );
+  }
+
+  OwnerModel copyWith({
+    String? id,
+    String? name,
+    String? phone,
+    List<String>? petsIds,
+    String? registrationDate,
+  }) {
+    return OwnerModel(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      phone: phone ?? this.phone,
+      petsIds: petsIds ?? this.petsIds,
+      registrationDate: registrationDate ?? this.registrationDate,
     );
   }
 
   Map<String, dynamic> toFirestore() {
     return {
-      'id': id ?? '',
+      'id': id,
       'name': name,
       'phone': phone,
       'petsIds': petsIds,
+      'registrationDate': _setRegistrationDate,
     };
+  }
+
+  List<String> toList() {
+    return [
+      id,
+      name,
+      phone,
+      petsIds.length.toString(),
+      registrationDate!,
+    ];
+  }
+
+  String get _setRegistrationDate =>
+      registrationDate ?? DateTime.now().toString();
+
+  @override
+  String toString() {
+    return 'OwnerModel{id: $id, name: $name, phone: $phone, petsIds: $petsIds, registrationDate: $registrationDate}';
   }
 }

--- a/lib/features/owners/data/local/models/pet_model.dart
+++ b/lib/features/owners/data/local/models/pet_model.dart
@@ -1,0 +1,113 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class PetModel {
+  final String id;
+  final String? ownerId;
+  final String name;
+  final String? type;
+  final String? breed;
+  final String? gender;
+  final String? vaccinations;
+  final String? treatments;
+  final String petReport;
+  final String? color;
+  final double? age;
+  final double? weight;
+
+  PetModel(
+      {required this.id,
+      this.ownerId,
+      required this.name,
+      this.type,
+      this.breed,
+      this.gender,
+      this.vaccinations,
+      this.treatments,
+      required this.petReport,
+      this.color,
+      this.age,
+      this.weight});
+
+  PetModel copyWith({
+    String? id,
+    String? ownerId,
+    String? name,
+    String? type,
+    String? breed,
+    String? gender,
+    String? vaccinations,
+    String? treatments,
+    String? petReport,
+    String? color,
+    double? age,
+    double? weight,
+  }) {
+    return PetModel(
+      id: id ?? this.id,
+      ownerId: ownerId ?? this.ownerId,
+      name: name ?? this.name,
+      type: type ?? this.type,
+      breed: breed ?? this.breed,
+      gender: gender ?? this.gender,
+      vaccinations: vaccinations ?? this.vaccinations,
+      treatments: treatments ?? this.treatments,
+      petReport: petReport ?? this.petReport,
+      color: color ?? this.color,
+      age: age ?? this.age,
+      weight: weight ?? this.weight,
+    );
+  }
+
+  factory PetModel.fromFirestore(QueryDocumentSnapshot<Object?> doc) {
+    final data = doc.data() as Map<String, dynamic>;
+    return PetModel(
+      id: doc.id,
+      ownerId: data['ownerId'],
+      name: data['name'],
+      type: data['type'],
+      breed: data['breed'],
+      gender: data['gender'],
+      vaccinations: data['vaccinations'],
+      treatments: data['treatments'],
+      petReport: data['petReport'],
+      color: data['color'],
+      age: data['age'],
+      weight: data['weight'],
+    );
+  }
+
+  /// Create a map with the only non-null values
+  Map<String, dynamic> toFirestore() {
+    final Map<String, dynamic> map = toMap();
+    for (var key in map.keys.toList()) {
+      if (map[key].toString().trim().isEmpty ||
+          map[key] == null ||
+          map[key] == 0) {
+        map.remove(key);
+      }
+    }
+    return map;
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'ownerId': ownerId,
+      'name': name,
+      'type': type,
+      'breed': breed,
+      'gender': gender,
+      'vaccinations': vaccinations,
+      'treatments': treatments,
+      'petReport': petReport,
+      'color': color,
+      'age': age,
+      'weight': weight,
+    };
+  }
+
+  @override
+  String toString() {
+    return 'PetModel(id: $id, ownerId: $ownerId, name: $name, type: $type, breed: $breed, gender: $gender, vaccinations: $vaccinations, treatments: $treatments, petReport: $petReport, color: $color, age: $age, weight: $weight)';
+  }
+}

--- a/lib/features/owners/data/local/repos/owners_repo.dart
+++ b/lib/features/owners/data/local/repos/owners_repo.dart
@@ -1,0 +1,37 @@
+import 'package:el_sharq_clinic/core/networking/firebase_services.dart';
+import 'package:el_sharq_clinic/features/owners/data/local/models/owner_model.dart';
+
+class OwnersRepo {
+  final FirebaseServices _firebaseServices;
+
+  OwnersRepo(this._firebaseServices);
+
+  Future<List<OwnerModel>> getOwners(
+      int clinicIndex, String? lastOwnerId) async {
+    return await _firebaseServices.getItems<OwnerModel>(
+      'owners',
+      clinicIndex: clinicIndex,
+      fromFirestore: OwnerModel.fromFirestore,
+      lastId: lastOwnerId,
+    );
+  }
+
+  Future<String?> getLastOwnerId(int clinicIndex, bool descendingOrder) async {
+    return await _firebaseServices.getFirstItemId(
+      'owners',
+      clinicIndex: clinicIndex,
+      descendingOrder: descendingOrder,
+    );
+  }
+
+  Future<bool> addNewOwner(int clinicIndex, OwnerModel ownerModel) async {
+    return await _firebaseServices.addItem<OwnerModel>(
+      'owners',
+      id: ownerModel.id,
+      clinicIndex: clinicIndex,
+      itemModel: ownerModel,
+      toFirestore: ownerModel.toFirestore,
+      idScheme: 'ONR',
+    );
+  }
+}

--- a/lib/features/owners/data/local/repos/pets_repo.dart
+++ b/lib/features/owners/data/local/repos/pets_repo.dart
@@ -1,0 +1,28 @@
+import 'package:el_sharq_clinic/core/networking/firebase_services.dart';
+import 'package:el_sharq_clinic/features/owners/data/local/models/pet_model.dart';
+
+class PetsRepo {
+  final FirebaseServices _firebaseServices;
+
+  PetsRepo(this._firebaseServices);
+
+  Future<bool> addPet(
+      int clinicIndex, String ownerId, PetModel petModel) async {
+    return await _firebaseServices.addItem<PetModel>(
+      'pets',
+      clinicIndex: clinicIndex,
+      itemModel: petModel,
+      id: petModel.id,
+      toFirestore: petModel.toFirestore,
+      idScheme: 'PET',
+    );
+  }
+
+  Future<String?> getLastPetId(int clinicIndex, bool descendingOrder) async {
+    return await _firebaseServices.getFirstItemId(
+      'pets',
+      clinicIndex: clinicIndex,
+      descendingOrder: descendingOrder,
+    );
+  }
+}

--- a/lib/features/owners/logic/cubit/owners_cubit.dart
+++ b/lib/features/owners/logic/cubit/owners_cubit.dart
@@ -1,30 +1,276 @@
 import 'dart:developer';
 
 import 'package:bloc/bloc.dart';
+import 'package:el_sharq_clinic/core/helpers/extensions.dart';
+import 'package:el_sharq_clinic/core/models/auth_data_model.dart';
+import 'package:el_sharq_clinic/features/owners/data/local/models/owner_model.dart';
+import 'package:el_sharq_clinic/features/owners/data/local/models/pet_model.dart';
+import 'package:el_sharq_clinic/features/owners/data/local/repos/owners_repo.dart';
+import 'package:el_sharq_clinic/features/owners/data/local/repos/pets_repo.dart';
 import 'package:flutter/material.dart';
 
 part 'owners_state.dart';
 
 class OwnersCubit extends Cubit<OwnersState> {
-  OwnersCubit() : super(OwnersInitial());
+  final OwnersRepo _ownersRepo;
+  final PetsRepo _petsRepo;
+  OwnersCubit(this._ownersRepo, this._petsRepo) : super(OwnersInitial());
 
+  AuthDataModel? authData;
   ValueNotifier<int> numberOfPetsNotifier = ValueNotifier(1);
-  GlobalKey<FormState> ownerFormKey = GlobalKey<FormState>();
+  ValueNotifier<bool> showDeleteButtonNotifier = ValueNotifier(false);
   List<GlobalKey<FormState>> petFormsKeys = [GlobalKey<FormState>()];
+  GlobalKey<FormState> ownerFormKey = GlobalKey<FormState>();
 
+  List<OwnerModel?> ownersList = [];
+  List<bool> selectedRows = [];
+  List<PetModel> petsList = [
+    PetModel(
+      id: 'PET000',
+      ownerId: null,
+      name: '',
+      petReport: '',
+    ),
+  ];
+  OwnerModel ownerInfo = OwnerModel(
+    id: 'ONR000',
+    name: '',
+    phone: '',
+    petsIds: [],
+  );
+
+  int pageLength = 10;
+
+  void setupSectionData(AuthDataModel authenticationData) {
+    _setAuthData(authenticationData);
+    _getPaginatedOwners();
+  }
+
+  void _setAuthData(AuthDataModel authenticationData) {
+    authData = authenticationData;
+  }
+
+  void _getPaginatedOwners() async {
+    emit(OwnersLoading());
+    try {
+      final List<OwnerModel> newOwnersList = await _ownersRepo.getOwners(
+        authData!.clinicIndex,
+        null,
+      );
+      log('New owners list length: ${newOwnersList.length}');
+
+      ownersList.addAll(newOwnersList);
+      log('Owners list length: ${ownersList.length}');
+      selectedRows = List.filled(ownersList.length, false);
+      emit(OwnersSuccess(owners: ownersList));
+    } catch (e) {
+      emit(OwnersError('Failed to get the owners'));
+    }
+  }
+
+  void getNextPage(int firstIndex) async {
+    String? lastOwnerId = ownersList.lastOrNull?.id;
+    final String? lastOwnerIdInFirestore = await getFirstOwnerId();
+    final bool isLastPage = ownersList.length - firstIndex <= pageLength;
+    if (lastOwnerIdInFirestore.toString() != lastOwnerId.toString() &&
+        isLastPage) {
+      try {
+        final List<OwnerModel> newOwnersList =
+            await _ownersRepo.getOwners(authData!.clinicIndex, lastOwnerId);
+        ownersList.addAll(newOwnersList);
+        selectedRows = List.filled(ownersList.length, false);
+        emit(OwnersSuccess(owners: ownersList));
+      } catch (e) {
+        emit(OwnersError('Failed to get the owners'));
+      }
+    }
+  }
+
+  // Owner
+  OwnerModel? getOwnerById(String ownerId) {
+    return ownersList.firstWhere((element) => element!.id == ownerId);
+  }
+
+  Future<String?> getLastOwnerId() async {
+    return await _ownersRepo.getLastOwnerId(authData!.clinicIndex, true);
+  }
+
+  Future<String?> getFirstOwnerId() async {
+    return await _ownersRepo.getLastOwnerId(authData!.clinicIndex, false);
+  }
+
+  // Pets
+  Future<String?> getLastPetId() async {
+    return await _petsRepo.getLastPetId(authData!.clinicIndex, true);
+  }
+
+  Future<void> refreshOwners() async {
+    emit(OwnersLoading());
+    try {
+      ownersList = await _ownersRepo.getOwners(authData!.clinicIndex, null);
+    } catch (e) {
+      emit(OwnersError('Failed to get the owners'));
+    }
+
+    emit(OwnersSuccess(owners: ownersList));
+  }
+
+  void validateThenSave() async {
+    if (_validateForms()) {
+      emit(OwnersLoading());
+      // Get last owner id in firestore to set the next owner id
+      final String? lastOwnerIdInFirestore = await getLastOwnerId();
+      // Get last pet id in firestore to set the next pet ids
+      final String? lastPetIdInFirestore = await getLastPetId();
+      // Save pet forms
+      for (int i = 0; i < petFormsKeys.length; i++) {
+        final petFormKey = petFormsKeys[i];
+        petFormKey.currentState!.save();
+      }
+      // Save owner form
+      ownerFormKey.currentState!.save();
+      // Handle the next owner and pets ids
+      _setOwnerAndPetsIds(
+          lastOwnerIdInFirestore: lastOwnerIdInFirestore,
+          lastPetIdInFirestore: lastPetIdInFirestore);
+      // Save owner and pets
+      final bool ownerSuccess = await _saveOwner();
+      final bool petsSuccess = await _saveAllPets();
+      // Take an action based on the success of the operation
+      if (ownerSuccess && petsSuccess) {
+        _onSuccessOperation();
+      } else {
+        emit(OwnersError('Failed to save the owner and pets'));
+      }
+    }
+  }
+
+  void _setOwnerAndPetsIds(
+      {String? lastOwnerIdInFirestore, String? lastPetIdInFirestore}) {
+    _setNextOwnerId(lastOwnerIdInFirestore);
+    _setNextPetsIds(lastPetIdInFirestore);
+    _setOwnerPetsIdsList(lastPetIdInFirestore);
+    _setOwnerIdForEachPet();
+  }
+
+  List<PetModel> _setOwnerIdForEachPet() => petsList =
+      petsList.map((pet) => pet.copyWith(ownerId: ownerInfo.id)).toList();
+
+  void _setNextOwnerId(String? lastOwnerIdInFirestore) {
+    if (lastOwnerIdInFirestore != null) {
+      ownerInfo = ownerInfo.copyWith(
+        id: lastOwnerIdInFirestore.getNextId(3, 'ONR'),
+      );
+    } else {
+      ownerInfo = ownerInfo.copyWith(id: 'ONR001');
+    }
+  }
+
+  void _setOwnerPetsIdsList(String? lastPetIdInFirestore) {
+    ownerInfo = ownerInfo.copyWith(
+      petsIds: petsList.map((pet) => pet.id).toList(),
+    );
+  }
+
+  void _setNextPetsIds(String? lastPetIdInFirestore) {
+    if (lastPetIdInFirestore != null) {
+      petsList = petsList.map((pet) {
+        lastPetIdInFirestore = lastPetIdInFirestore!.getNextId(3, 'PET');
+        return pet.copyWith(id: lastPetIdInFirestore);
+      }).toList();
+    } else {
+      lastPetIdInFirestore = 'PET000';
+      petsList = petsList.map((pet) {
+        lastPetIdInFirestore = lastPetIdInFirestore!.getNextId(3, 'PET');
+        return pet.copyWith(id: lastPetIdInFirestore);
+      }).toList();
+    }
+  }
+
+  void onSaveOwnerFormField(String field, String? value) {
+    ownerInfo = ownerInfo.copyWith(
+      name: field == 'Name' ? value : ownerInfo.name,
+      phone: field == 'Phone' ? value : ownerInfo.phone,
+    );
+  }
+
+  void onSavePetFormField(String field, String? value, int index) {
+    final petModel = petsList[index];
+
+    petsList[index] = petModel.copyWith(
+      name: field == 'Name' ? value : petModel.name,
+      gender: field == 'Gender' ? value : petModel.gender,
+      age: field == 'Age' ? double.tryParse(value!) : petModel.age,
+      type: field == 'Type' ? value : petModel.type,
+      breed: field == 'Breed' ? value : petModel.breed,
+      color: field == 'Color' ? value : petModel.color,
+      weight: field == 'Weight' ? double.tryParse(value!) : petModel.weight,
+      petReport: field == 'Pet Report' ? value : petModel.petReport,
+      vaccinations: field == 'Vaccinations' ? value : petModel.vaccinations,
+      treatments: field == 'Treatments' ? value : petModel.treatments,
+    );
+  }
+
+  Future<bool> _saveOwner() async {
+    return await _ownersRepo.addNewOwner(authData!.clinicIndex, ownerInfo);
+  }
+
+  Future<bool> _savePet(PetModel petModel) async {
+    return await _petsRepo.addPet(
+        authData!.clinicIndex, ownerInfo.id, petModel);
+  }
+
+  Future<bool> _saveAllPets() async {
+    bool success = true;
+    for (final pet in petsList) {
+      success = await _savePet(pet);
+      if (!success) {
+        success = false;
+        break;
+      }
+    }
+    return success;
+  }
+
+  void _onSuccessOperation() async {
+    await refreshOwners();
+    selectedRows = List.filled(ownersList.length, false);
+    emit(OwnersSuccess(owners: ownersList));
+  }
+
+  // UI Logic
   void setupNewSheet() {
     numberOfPetsNotifier = ValueNotifier<int>(1);
+  }
+
+  void setupExistingSheet(OwnerModel owner) {
+    numberOfPetsNotifier = ValueNotifier<int>(owner.petsIds.length);
+    petFormsKeys = List.generate(
+      owner.petsIds.length,
+      (index) => GlobalKey<FormState>(),
+    );
+    // Set owner info
+    ownerInfo = owner;
   }
 
   void incrementPets() {
     numberOfPetsNotifier.value++;
     petFormsKeys.add(GlobalKey<FormState>());
+    petsList.add(
+      PetModel(
+        id: 'PET000',
+        ownerId: null,
+        name: '',
+        petReport: '',
+      ),
+    );
     emit(OwnersPetsChanged(numberOfPetsNotifier.value));
   }
 
   void decrementPets(int index) {
     numberOfPetsNotifier.value--;
     petFormsKeys.removeAt(index);
+    petsList.removeAt(index);
     emit(OwnersPetsChanged(numberOfPetsNotifier.value));
   }
 
@@ -43,11 +289,17 @@ class OwnersCubit extends Cubit<OwnersState> {
     return isValid;
   }
 
-  void validateThenSave() {
-    if (_validateForms()) {
-      log('All forms are valid');
+  void onMultiSelection(int index, bool selected) {
+    if (selectedRows.elementAt(index)) {
+      selectedRows[index] = false;
     } else {
-      log('Some forms are invalid');
+      selectedRows[index] = true;
+    }
+
+    if (selectedRows.any((element) => element)) {
+      showDeleteButtonNotifier.value = true;
+    } else {
+      showDeleteButtonNotifier.value = false;
     }
   }
 }

--- a/lib/features/owners/logic/cubit/owners_state.dart
+++ b/lib/features/owners/logic/cubit/owners_state.dart
@@ -4,8 +4,30 @@ abstract class OwnersState {}
 
 final class OwnersInitial extends OwnersState {}
 
+final class OwnersLoading extends OwnersState {}
+
+final class OwnersSuccess extends OwnersState {
+  final List<OwnerModel?> owners;
+
+  OwnersSuccess({required this.owners});
+}
+
+final class OwnersError extends OwnersState {
+  final String errorMessage;
+
+  OwnersError(this.errorMessage);
+}
+
 final class OwnersPetsChanged extends OwnersState {
   final int numberOfPets;
 
   OwnersPetsChanged(this.numberOfPets);
 }
+
+// Owner
+
+final class OwnerAdded extends OwnersState {}
+
+final class OwnerUpdated extends OwnersState {}
+
+final class OwnerDeleted extends OwnersState {}

--- a/lib/features/owners/ui/owners_section.dart
+++ b/lib/features/owners/ui/owners_section.dart
@@ -3,9 +3,11 @@ import 'package:el_sharq_clinic/core/models/auth_data_model.dart';
 import 'package:el_sharq_clinic/core/widgets/section_action_button.dart';
 import 'package:el_sharq_clinic/core/widgets/section_container.dart';
 import 'package:el_sharq_clinic/core/widgets/section_search_bar.dart';
+import 'package:el_sharq_clinic/features/owners/logic/cubit/owners_cubit.dart';
 import 'package:el_sharq_clinic/features/owners/ui/widgets/owners_body.dart';
 import 'package:el_sharq_clinic/features/owners/ui/widgets/owners_side_sheet.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
 class OwnersSection extends StatelessWidget {
   const OwnersSection({super.key, required this.authData});
@@ -14,6 +16,8 @@ class OwnersSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    context.read<OwnersCubit>().setupSectionData(authData);
+
     return SectionContainer(
       title: 'Owners',
       actions: [
@@ -29,7 +33,7 @@ class OwnersSection extends StatelessWidget {
           newText: 'New Owner',
           onNewPressed: () => showOwnerSheet(context, 'New Owner'),
           onDeletePressed: () {},
-          valueNotifier: ValueNotifier(false),
+          valueNotifier: context.read<OwnersCubit>().showDeleteButtonNotifier,
         ),
       ],
       child: Expanded(

--- a/lib/features/owners/ui/widgets/owners_row_action_button.dart
+++ b/lib/features/owners/ui/widgets/owners_row_action_button.dart
@@ -28,7 +28,7 @@ class OwnersRowActionButton extends StatelessWidget {
             value: 'Add Pet',
             onTap: () {},
             child: const Text(
-              'Edit',
+              'Add Pet',
               style: AppTextStyles.font14DarkGreyMedium,
             ),
           ),

--- a/lib/features/owners/ui/widgets/owners_side_sheet.dart
+++ b/lib/features/owners/ui/widgets/owners_side_sheet.dart
@@ -15,10 +15,9 @@ Future<void> showOwnerSheet(BuildContext context, String title,
     {OwnerModel? ownerModel, bool editable = true}) async {
   final bool newOwner = ownerModel == null;
   final OwnersCubit ownersCubit = context.read<OwnersCubit>();
-  ownersCubit.setupNewSheet();
-  // newOwner
-  //     ? OwnersCubit.setupNewModeControllers()
-  //     : OwnersCubit.setupShowModeControllers(caseHistoryModel);
+  newOwner
+      ? ownersCubit.setupNewSheet()
+      : ownersCubit.setupExistingSheet(ownerModel);
 
   await showCustomSideSheet(
     context: context,
@@ -27,11 +26,14 @@ Future<void> showOwnerSheet(BuildContext context, String title,
         SectionTitle(title: title),
         verticalSpace(50),
         if (newOwner) _buildAddPetButton(context, ownersCubit),
-        if (!newOwner) _buildOwnerId(context),
+        if (!newOwner) _buildOwnerId(ownerModel.id!),
         verticalSpace(50),
         SideSheetOwnerContainer(
           editable: editable,
           ownerFormKey: ownersCubit.ownerFormKey,
+          ownerModel: ownerModel,
+          onSaved: (field, value) =>
+              ownersCubit.onSaveOwnerFormField(field, value),
         ),
         verticalSpace(50),
         SideSheetPetsColumn(
@@ -39,6 +41,8 @@ Future<void> showOwnerSheet(BuildContext context, String title,
           petsNumberNotifier: ownersCubit.numberOfPetsNotifier,
           petFormsKeys: ownersCubit.petFormsKeys,
           onDecrementPets: (index) => ownersCubit.decrementPets(index),
+          onSaved: (field, value, index) =>
+              ownersCubit.onSavePetFormField(field, value, index),
         ),
         verticalSpace(100),
         _buildActionIfNeeded(context, newOwner, editable),
@@ -65,8 +69,9 @@ _buildActionIfNeeded(BuildContext context, bool newCase, bool editMode) {
   return const SizedBox.shrink();
 }
 
-AppTextField _buildOwnerId(BuildContext context) {
-  return const AppTextField(
+AppTextField _buildOwnerId(String id) {
+  return AppTextField(
+    initialValue: id,
     hint: 'Owner ID',
     enabled: false,
     width: double.infinity,

--- a/lib/features/owners/ui/widgets/side_sheet_owner_container.dart
+++ b/lib/features/owners/ui/widgets/side_sheet_owner_container.dart
@@ -1,6 +1,7 @@
 import 'package:el_sharq_clinic/core/theming/app_colors.dart';
 import 'package:el_sharq_clinic/core/theming/app_text_styles.dart';
 import 'package:el_sharq_clinic/core/widgets/fields_row.dart';
+import 'package:el_sharq_clinic/features/owners/data/local/models/owner_model.dart';
 import 'package:flutter/material.dart';
 
 class SideSheetOwnerContainer extends StatelessWidget {
@@ -8,13 +9,18 @@ class SideSheetOwnerContainer extends StatelessWidget {
     super.key,
     required this.editable,
     required this.ownerFormKey,
+    this.ownerModel,
+    this.onSaved,
   });
 
   final bool editable;
   final GlobalKey<FormState> ownerFormKey;
+  final OwnerModel? ownerModel;
+  final void Function(String field, String? value)? onSaved;
 
   @override
   Widget build(BuildContext context) {
+    final bool withOwner = ownerModel != null;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -36,6 +42,9 @@ class SideSheetOwnerContainer extends StatelessWidget {
                 'Name',
                 'Phone',
               ],
+              onSaved: onSaved,
+              firstText: withOwner ? ownerModel!.name : null,
+              secondText: withOwner ? ownerModel!.phone : null,
               validations: const [true, true],
               enabled: editable,
             ),

--- a/lib/features/owners/ui/widgets/side_sheet_pet_container.dart
+++ b/lib/features/owners/ui/widgets/side_sheet_pet_container.dart
@@ -12,11 +12,13 @@ class SideSheetPetContainer extends StatelessWidget {
     required this.editable,
     required this.index,
     required this.petFormKey,
+    this.onSaved,
   });
 
   final int index;
   final bool editable;
   final GlobalKey<FormState> petFormKey;
+  final void Function(String field, String? value)? onSaved;
 
   @override
   Widget build(BuildContext context) {
@@ -50,6 +52,11 @@ class SideSheetPetContainer extends StatelessWidget {
                   enabled: editable,
                   width: double.infinity,
                   insideHint: false,
+                  onSaved: (value) {
+                    if (onSaved != null) {
+                      onSaved!('Name', value);
+                    }
+                  },
                 ),
                 verticalSpace(15),
                 FieldsRow(
@@ -59,6 +66,7 @@ class SideSheetPetContainer extends StatelessWidget {
                   ],
                   validations: const [false, false],
                   enabled: editable,
+                  onSaved: onSaved,
                 ),
                 verticalSpace(15),
                 FieldsRow(
@@ -68,26 +76,49 @@ class SideSheetPetContainer extends StatelessWidget {
                   ],
                   validations: const [false, false],
                   enabled: editable,
+                  onSaved: onSaved,
                 ),
                 verticalSpace(15),
                 FieldsRow(
                   fields: const [
-                    'Vaccination',
+                    'Color',
+                    'Weight',
+                  ],
+                  validations: const [false, false],
+                  enabled: editable,
+                  onSaved: onSaved,
+                ),
+                verticalSpace(15),
+                FieldsRow(
+                  fields: const [
+                    'Vaccinations',
                     'Treatments',
                   ],
                   validations: const [false, false],
                   enabled: editable,
                   isMultiline: true,
+                  onSaved: onSaved,
                 ),
                 verticalSpace(15),
                 AppTextField(
                   hint: 'Pet Report',
-                  initialValue: AppConstant.petReportScheme,
+                  initialValue: AppConstant.petProfileReportScheme,
+                  validator: (value) {
+                    if (value!.trim().isEmpty) {
+                      return 'Please write a Pet Report';
+                    }
+                    return null;
+                  },
                   enabled: editable,
                   width: double.infinity,
-                  height: 150,
+                  height: 175,
                   isMultiline: true,
                   insideHint: false,
+                  onSaved: (value) {
+                    if (onSaved != null) {
+                      onSaved!('Pet Report', value);
+                    }
+                  },
                 ),
               ],
             ),

--- a/lib/features/owners/ui/widgets/side_sheet_pets_column.dart
+++ b/lib/features/owners/ui/widgets/side_sheet_pets_column.dart
@@ -9,12 +9,14 @@ class SideSheetPetsColumn extends StatelessWidget {
       required this.editable,
       required this.petsNumberNotifier,
       required this.petFormsKeys,
-      required this.onDecrementPets});
+      required this.onDecrementPets,
+      this.onSaved});
 
   final bool editable;
   final ValueNotifier<int> petsNumberNotifier;
   final List<GlobalKey<FormState>> petFormsKeys;
   final void Function(int index) onDecrementPets;
+  final void Function(String field, String? value, int petIndex)? onSaved;
 
   @override
   Widget build(BuildContext context) {
@@ -39,8 +41,11 @@ class SideSheetPetsColumn extends StatelessWidget {
               petFormKey: petFormsKeys[index],
               index: index + 1,
               editable: editable,
+              onSaved: (field, value) {
+                if (onSaved != null) onSaved!(field, value, index);
+              },
             ),
-            if (index != 0) _buildRemoveButton(index),
+            if (index != 0 && editable) _buildRemoveButton(index),
           ],
         ),
       ),


### PR DESCRIPTION
- Added `OwnersRepo` and `PetsRepo` to handle data services.
- Added `OwnersRepo` and `PetsRepo` to DI file.
- Refactored the pet report scheme to be separated into `petCaseReportScheme` & `PetProfileReportScheme`.
- Added `getNextId` as an extension method to String class.
- Refactored `addItem` method in `FirebaseServices` class to receive `id` param instead of handling it inside the method.
- Added `onSaved` param to `AppTextField` widget to handle saving process within the form state.
- Refactored the `FieldsRow` widget to receive text to display within its text fields.
- Refactored the `CaseHistoryModel` to make the `id` param required and to drop null values in `toFirestore` method to reduce the data and network headache.
- Refactored the `OwnerModel` to make the `id` param required.
- Created a `PetModel` to hold and manipulate the pets data.
- Implemented the adding data logic in `OwnersCubit` and some retrieving data logic.
- Added some states to `OwnersState` to handle this section states.
- Handle logic of adding new owner in UI.