### PR TITLE
Finish Deleting Owner Feature✅

### DIFF
--- a/lib/core/widgets/animated_loading_indicator.dart
+++ b/lib/core/widgets/animated_loading_indicator.dart
@@ -1,0 +1,40 @@
+import 'package:el_sharq_clinic/core/theming/app_colors.dart';
+import 'package:flutter/material.dart';
+
+class AnimatedLoadingIndicator extends StatefulWidget {
+  const AnimatedLoadingIndicator({super.key});
+
+  @override
+  State<AnimatedLoadingIndicator> createState() =>
+      _AnimatedLoadingIndicatorState();
+}
+
+class _AnimatedLoadingIndicatorState extends State<AnimatedLoadingIndicator>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+        vsync: this, duration: const Duration(milliseconds: 500));
+    _controller.repeat(reverse: true);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FadeTransition(
+        opacity: _controller,
+        child: const Icon(
+          Icons.pets,
+          size: 60,
+          color: AppColors.blue,
+        ));
+  }
+}

--- a/lib/features/cases/data/local/repos/case_history_repo.dart
+++ b/lib/features/cases/data/local/repos/case_history_repo.dart
@@ -6,10 +6,12 @@ class CaseHistoryRepo {
 
   CaseHistoryRepo(this._firebaseServices);
 
+  final String collectionName = 'cases';
+
   Future<List<CaseHistoryModel>> getAllCases(
       int clinicIndex, String? lastCaseId) async {
     return await _firebaseServices.getItems<CaseHistoryModel>(
-      'cases',
+      collectionName,
       clinicIndex: clinicIndex,
       fromFirestore: CaseHistoryModel.fromFirestore,
       lastId: lastCaseId,
@@ -18,7 +20,7 @@ class CaseHistoryRepo {
 
   Future<String?> getFirstCaseId(int clinicIndex, bool descendingOrder) async {
     return await _firebaseServices.getFirstItemId(
-      'cases',
+      collectionName,
       clinicIndex: clinicIndex,
       descendingOrder: descendingOrder,
     );
@@ -26,7 +28,7 @@ class CaseHistoryRepo {
 
   Future<bool> addNewCase(CaseHistoryModel caseModel, int clinicIndex) async {
     return await _firebaseServices.addItem<CaseHistoryModel>(
-      'cases',
+      collectionName,
       itemModel: caseModel,
       id: caseModel.id,
       clinicIndex: clinicIndex,
@@ -37,7 +39,7 @@ class CaseHistoryRepo {
 
   Future<bool> updateCase(CaseHistoryModel caseModel, int clinicIndex) async {
     return await _firebaseServices.updateItem<CaseHistoryModel>(
-      'cases',
+      collectionName,
       itemModel: caseModel,
       clinicIndex: clinicIndex,
       toFirestore: caseModel.toFirestore,
@@ -47,7 +49,7 @@ class CaseHistoryRepo {
 
   Future<bool> deleteCase(String caseId, int clinicIndex) async {
     return await _firebaseServices.deleteItem(
-      'cases',
+      collectionName,
       id: caseId,
       clinicIndex: clinicIndex,
     );

--- a/lib/features/cases/logic/cubit/case_history_cubit.dart
+++ b/lib/features/cases/logic/cubit/case_history_cubit.dart
@@ -1,6 +1,7 @@
 import 'package:el_sharq_clinic/core/helpers/constants.dart';
 import 'package:el_sharq_clinic/core/helpers/extensions.dart';
 import 'package:el_sharq_clinic/core/models/auth_data_model.dart';
+import 'package:el_sharq_clinic/core/widgets/animated_loading_indicator.dart';
 import 'package:el_sharq_clinic/core/widgets/app_dialog.dart';
 import 'package:el_sharq_clinic/core/widgets/app_text_button.dart';
 import 'package:el_sharq_clinic/features/cases/data/local/models/case_history_model.dart';
@@ -203,10 +204,11 @@ class CaseHistoryCubit extends Cubit<CaseHistoryState> {
         }
       }
       _resetShowDeleteButtonNotifier();
+      emit(DeleteCaseHistorySuccess());
+      _onSuccessOperation();
     } catch (e) {
       emit(CaseHistoryError('Failed to delete these cases'));
     }
-    _onSuccessOperation();
   }
 
   void _onSuccessOperation() async {

--- a/lib/features/cases/logic/cubit/case_history_state.dart
+++ b/lib/features/cases/logic/cubit/case_history_state.dart
@@ -78,7 +78,7 @@ final class NewCaseHistoryLoading extends CaseHistoryState {
         context: context,
         barrierDismissible: false,
         builder: (context) {
-          return const Center(child: CircularProgressIndicator());
+          return const Center(child: AnimatedLoadingIndicator());
         });
   }
 }
@@ -146,6 +146,28 @@ final class UpdateCaseHistorySuccess extends CaseHistoryState {
       builder: (ctx) => const AppDialog(
         title: 'Success',
         content: 'Case updated successfully',
+        dialogType: DialogType.success,
+      ),
+    );
+
+    // Hide success dialog after 2 seconds
+    Future.delayed(const Duration(seconds: 2), () {
+      if (context.mounted) {
+        context.pop();
+      }
+    });
+  }
+}
+
+final class DeleteCaseHistorySuccess extends CaseHistoryState {
+  @override
+  void takeAction(BuildContext context) {
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (ctx) => const AppDialog(
+        title: 'Success',
+        content: 'Cases deleted successfully',
         dialogType: DialogType.success,
       ),
     );

--- a/lib/features/cases/ui/widgets/case_history_bloc_listener.dart
+++ b/lib/features/cases/ui/widgets/case_history_bloc_listener.dart
@@ -15,7 +15,8 @@ class CaseHistoryBlocListener extends StatelessWidget {
           current is NewCaseHistoryFailure ||
           current is NewCaseHistorySuccess ||
           current is NewCaseHistoryInvalid ||
-          current is UpdateCaseHistorySuccess,
+          current is UpdateCaseHistorySuccess ||
+          current is DeleteCaseHistorySuccess,
       listener: (context, state) {
         state.takeAction(context);
       },

--- a/lib/features/cases/ui/widgets/case_history_body.dart
+++ b/lib/features/cases/ui/widgets/case_history_body.dart
@@ -1,6 +1,7 @@
 import 'package:el_sharq_clinic/core/helpers/constants.dart';
 import 'package:el_sharq_clinic/core/theming/app_colors.dart';
 import 'package:el_sharq_clinic/core/theming/app_text_styles.dart';
+import 'package:el_sharq_clinic/core/widgets/animated_loading_indicator.dart';
 import 'package:el_sharq_clinic/core/widgets/custom_table.dart';
 import 'package:el_sharq_clinic/core/widgets/custom_table_data_source.dart';
 import 'package:el_sharq_clinic/core/widgets/section_details_container.dart';
@@ -51,7 +52,7 @@ class _CaseHistoryBodyState extends State<CaseHistoryBody> {
       );
     }
 
-    return const Center(child: CircularProgressIndicator());
+    return const Center(child: AnimatedLoadingIndicator());
   }
 
   CustomTable _buildSuccess(BuildContext context) {

--- a/lib/features/owners/data/local/repos/owners_repo.dart
+++ b/lib/features/owners/data/local/repos/owners_repo.dart
@@ -6,10 +6,12 @@ class OwnersRepo {
 
   OwnersRepo(this._firebaseServices);
 
+  final String collectionName = 'owners';
+
   Future<List<OwnerModel>> getOwners(
       int clinicIndex, String? lastOwnerId) async {
     return await _firebaseServices.getItems<OwnerModel>(
-      'owners',
+      collectionName,
       clinicIndex: clinicIndex,
       fromFirestore: OwnerModel.fromFirestore,
       lastId: lastOwnerId,
@@ -18,7 +20,7 @@ class OwnersRepo {
 
   Future<String?> getLastOwnerId(int clinicIndex, bool descendingOrder) async {
     return await _firebaseServices.getFirstItemId(
-      'owners',
+      collectionName,
       clinicIndex: clinicIndex,
       descendingOrder: descendingOrder,
     );
@@ -26,7 +28,7 @@ class OwnersRepo {
 
   Future<bool> addNewOwner(int clinicIndex, OwnerModel ownerModel) async {
     return await _firebaseServices.addItem<OwnerModel>(
-      'owners',
+      collectionName,
       id: ownerModel.id,
       clinicIndex: clinicIndex,
       itemModel: ownerModel,
@@ -37,10 +39,18 @@ class OwnersRepo {
 
   Future<bool> updateOwner(int clinicIndex, OwnerModel ownerModel) async {
     return await _firebaseServices.updateItem<OwnerModel>(
-      'owners',
+      collectionName,
       itemModel: ownerModel,
       id: ownerModel.id,
       toFirestore: ownerModel.toFirestore,
+      clinicIndex: clinicIndex,
+    );
+  }
+
+  Future<bool> deleteOwner(int clinicIndex, String id) async {
+    return await _firebaseServices.deleteItem(
+      collectionName,
+      id: id,
       clinicIndex: clinicIndex,
     );
   }

--- a/lib/features/owners/data/local/repos/pets_repo.dart
+++ b/lib/features/owners/data/local/repos/pets_repo.dart
@@ -6,10 +6,12 @@ class PetsRepo {
 
   PetsRepo(this._firebaseServices);
 
+  final String collectionName = 'pets';
+
   Future<bool> addPet(
       int clinicIndex, String ownerId, PetModel petModel) async {
     return await _firebaseServices.addItem<PetModel>(
-      'pets',
+      collectionName,
       clinicIndex: clinicIndex,
       itemModel: petModel,
       id: petModel.id,
@@ -20,14 +22,14 @@ class PetsRepo {
 
   Future<String?> getLastPetId(int clinicIndex, bool descendingOrder) async {
     return await _firebaseServices.getFirstItemId(
-      'pets',
+      collectionName,
       clinicIndex: clinicIndex,
       descendingOrder: descendingOrder,
     );
   }
 
   Future<List<PetModel>> getPetsByIds(int clinicIndex, List<String> ids) async {
-    return _firebaseServices.getItemsByIds<PetModel>('pets',
+    return _firebaseServices.getItemsByIds<PetModel>(collectionName,
         clinicIndex: clinicIndex,
         ids: ids,
         fromFirestore: PetModel.fromFirestore);
@@ -35,7 +37,7 @@ class PetsRepo {
 
   Future<bool> updatePet(int clinicIndex, PetModel petModel) async {
     return _firebaseServices.updateItem<PetModel>(
-      'pets',
+      collectionName,
       itemModel: petModel,
       id: petModel.id,
       toFirestore: petModel.toFirestore,
@@ -45,7 +47,7 @@ class PetsRepo {
 
   Future<bool> deletePet(int clinicIndex, String id) async {
     return await _firebaseServices.deleteItem(
-      'pets',
+      collectionName,
       id: id,
       clinicIndex: clinicIndex,
     );

--- a/lib/features/owners/logic/cubit/owners_state.dart
+++ b/lib/features/owners/logic/cubit/owners_state.dart
@@ -54,7 +54,7 @@ final class OwnerLoading extends OwnersState {
         context: context,
         barrierDismissible: false,
         builder: (context) {
-          return const Center(child: CircularProgressIndicator());
+          return const Center(child: AnimatedLoadingIndicator());
         });
   }
 }
@@ -111,4 +111,26 @@ final class OwnerUpdated extends OwnersState {
   }
 }
 
-final class OwnerDeleted extends OwnersState {}
+final class OwnerDeleted extends OwnersState {
+  @override
+  void takeAction(BuildContext context) {
+    super.takeAction(context);
+
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (ctx) => const AppDialog(
+        title: 'Success',
+        content: 'Owner profile deleted successfully',
+        dialogType: DialogType.success,
+      ),
+    );
+
+    // Hide success dialog after 2 seconds
+    Future.delayed(const Duration(seconds: 2), () {
+      if (context.mounted) {
+        context.pop();
+      }
+    });
+  }
+}

--- a/lib/features/owners/ui/owners_section.dart
+++ b/lib/features/owners/ui/owners_section.dart
@@ -31,7 +31,8 @@ class OwnersSection extends StatelessWidget {
         SectionActionButton(
           newText: 'New Owner',
           onNewPressed: () => showOwnerSheet(context, 'New Owner'),
-          onDeletePressed: () {},
+          onDeletePressed: () =>
+              context.read<OwnersCubit>().onDeleteSelectedOwners(),
           valueNotifier: context.read<OwnersCubit>().showDeleteButtonNotifier,
         ),
       ],

--- a/lib/features/owners/ui/widgets/owners_bloc_listener.dart
+++ b/lib/features/owners/ui/widgets/owners_bloc_listener.dart
@@ -12,7 +12,8 @@ class OwnersBlocListener extends StatelessWidget {
           current is OwnerLoading ||
           current is OwnersError ||
           current is NewOwnerAdded ||
-          current is OwnerUpdated,
+          current is OwnerUpdated ||
+          current is OwnerDeleted,
       listener: (context, state) {
         state.takeAction(context);
       },

--- a/lib/features/owners/ui/widgets/owners_body.dart
+++ b/lib/features/owners/ui/widgets/owners_body.dart
@@ -1,5 +1,6 @@
 import 'package:el_sharq_clinic/core/helpers/constants.dart';
 import 'package:el_sharq_clinic/core/theming/app_colors.dart';
+import 'package:el_sharq_clinic/core/widgets/animated_loading_indicator.dart';
 import 'package:el_sharq_clinic/core/widgets/custom_table.dart';
 import 'package:el_sharq_clinic/core/widgets/custom_table_data_source.dart';
 import 'package:el_sharq_clinic/core/widgets/section_details_container.dart';
@@ -46,7 +47,7 @@ class _OwnersBodyState extends State<OwnersBody> {
         child: Text(state.errorMessage),
       );
     }
-    return const Center(child: CircularProgressIndicator());
+    return const Center(child: AnimatedLoadingIndicator());
   }
 
   CustomTable _buildSuccess(BuildContext context) {

--- a/lib/features/owners/ui/widgets/owners_row_action_button.dart
+++ b/lib/features/owners/ui/widgets/owners_row_action_button.dart
@@ -45,9 +45,11 @@ class OwnersRowActionButton extends StatelessWidget {
               showDialog(
                 context: ctx,
                 builder: (_) => AppAlertDialog(
-                  alertMessage: 'Are you sure you want to delete this case?\n'
+                  alertMessage:
+                      'Are you sure you want to delete this owner profile?\n'
                       'This action cannot be undone.',
                   onConfirm: () {
+                    context.read<OwnersCubit>().onDeleteOwner(id);
                     ctx.pop();
                   },
                   onCancel: () {


### PR DESCRIPTION
- Added  `AnimatedLoadingIndicator` to be a loading indicator rather than the legacy indicator.
- Added `DeleteCaseHistorySuccess` to to be emitted when delete case.
- Made `CaseHistoryBlocListener` and `OwnersBlocListener` listen to delete state of each class.
- Refactored the app repos to have a `collectionName` field to control which collection should be used to manipulate its data.
- Handled the deletion process logic in `OwnersRepo`, `PetsRepo, and `OwnersCubit`.