### PR TITLE
Refactoring Getting Services & Products Data✅

### DIFF
--- a/lib/core/di/dependency_injection.dart
+++ b/lib/core/di/dependency_injection.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:el_sharq_clinic/core/logic/cubit/main_cubit.dart';
 import 'package:el_sharq_clinic/core/networking/firebase_factory.dart';
 import 'package:el_sharq_clinic/features/cases/data/local/repos/case_history_repo.dart';
 import 'package:el_sharq_clinic/core/networking/firebase_services.dart';
@@ -36,6 +37,7 @@ void setupGetIt() {
   getIt.registerFactory<DoctorsCubit>(() => DoctorsCubit(getIt()));
   getIt.registerFactory<ServicesCubit>(() => ServicesCubit(getIt()));
   getIt.registerFactory<ProductsCubit>(() => ProductsCubit(getIt()));
+  getIt.registerFactory<MainCubit>(() => MainCubit());
 
   // Repos
   getIt.registerLazySingleton<AuthRepo>(() => AuthRepo(getIt()));

--- a/lib/core/logic/cubit/main_cubit.dart
+++ b/lib/core/logic/cubit/main_cubit.dart
@@ -1,0 +1,27 @@
+import 'package:bloc/bloc.dart';
+import 'package:el_sharq_clinic/features/products/data/models/product_model.dart';
+import 'package:el_sharq_clinic/features/services/data/models/service_model.dart';
+
+part 'main_state.dart';
+
+class MainCubit extends Cubit<MainState> {
+  MainCubit() : super(MainInitial());
+
+  // Variables
+  List<ProductModel> medicinesList = [];
+  List<ProductModel> accessorieList = [];
+  List<ServiceModel> servicesList = [];
+
+  // Functions
+  void updateMedicinesList(List<ProductModel> medicines) {
+    medicinesList = medicines;
+  }
+
+  void updateAccessoriesList(List<ProductModel> accessories) {
+    accessorieList = accessories;
+  }
+
+  void updateServicesList(List<ServiceModel> services) {
+    servicesList = services;
+  }
+}

--- a/lib/core/logic/cubit/main_state.dart
+++ b/lib/core/logic/cubit/main_state.dart
@@ -1,0 +1,5 @@
+part of 'main_cubit.dart';
+
+abstract class MainState {}
+
+final class MainInitial extends MainState {}

--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -1,4 +1,5 @@
 import 'package:el_sharq_clinic/core/di/dependency_injection.dart';
+import 'package:el_sharq_clinic/core/logic/cubit/main_cubit.dart';
 import 'package:el_sharq_clinic/core/models/auth_data_model.dart';
 import 'package:el_sharq_clinic/core/routing/app_routes.dart';
 import 'package:el_sharq_clinic/features/auth/logic/cubit/auth_cubit.dart';
@@ -22,8 +23,11 @@ class AppRouter {
         );
       case AppRoutes.home:
         return MaterialPageRoute(
-          builder: (_) => HomeLayout(
-            authData: arguments as AuthDataModel,
+          builder: (_) => BlocProvider<MainCubit>(
+            create: (context) => getIt<MainCubit>(),
+            child: HomeLayout(
+              authData: arguments as AuthDataModel,
+            ),
           ),
         );
       default:

--- a/lib/features/home/ui/home_layout.dart
+++ b/lib/features/home/ui/home_layout.dart
@@ -83,13 +83,13 @@ class _HomeLayoutState extends State<HomeLayout> {
             child: const DoctorsSection(),
           ),
       (context) => BlocProvider<ServicesCubit>(
-            create: (context) =>
-                getIt<ServicesCubit>()..setupSectionData(widget.authData),
+            create: (context) => getIt<ServicesCubit>()
+              ..setupSectionData(widget.authData, context),
             child: const ServicesSection(),
           ),
       (context) => BlocProvider<ProductsCubit>(
-            create: (context) =>
-                getIt<ProductsCubit>()..setupSectionData(widget.authData),
+            create: (context) => getIt<ProductsCubit>()
+              ..setupSectionData(widget.authData, context),
             child: const ProductsSection(),
           ),
     ];

--- a/lib/features/products/logic/cubit/products_state.dart
+++ b/lib/features/products/logic/cubit/products_state.dart
@@ -1,23 +1,40 @@
 part of 'products_cubit.dart';
 
 abstract class ProductsState {
-  final ProductType? selectedProductType;
-  ProductsState({this.selectedProductType});
+  final ProductType selectedProductType;
+  ProductsState({required this.selectedProductType});
   takeAction(BuildContext context) {}
 }
 
 final class ProductsInitial extends ProductsState {
-  ProductsInitial({super.selectedProductType});
+  ProductsInitial({required super.selectedProductType});
 }
 
 final class ProductsLoading extends ProductsState {
-  ProductsLoading({super.selectedProductType});
+  ProductsLoading({required super.selectedProductType});
 }
 
 final class ProductsSuccess extends ProductsState {
   final List<ProductModel> products;
 
   ProductsSuccess({required this.products, required super.selectedProductType});
+
+  @override
+  void takeAction(BuildContext context) {
+    if (products.isNotEmpty) {
+      if (selectedProductType == ProductType.medicines) {
+        context.read<MainCubit>().updateMedicinesList(products);
+      } else {
+        context.read<MainCubit>().updateAccessoriesList(products);
+      }
+    }
+  }
+}
+
+final class ProductsSearchSuccess extends ProductsState {
+  final List<ProductModel> products;
+  ProductsSearchSuccess(
+      {required this.products, required super.selectedProductType});
 }
 
 final class ProductsError extends ProductsState {

--- a/lib/features/products/ui/widgets/products_bloc_listener.dart
+++ b/lib/features/products/ui/widgets/products_bloc_listener.dart
@@ -11,7 +11,8 @@ class ProductsBlocListener extends StatelessWidget {
       listenWhen: (previous, current) =>
           current is ProductInProgress ||
           current is ProductInvalid ||
-          current is ProductSuccessOperation,
+          current is ProductSuccessOperation ||
+          current is ProductsSuccess,
       listener: (context, state) {
         state.takeAction(context);
       },

--- a/lib/features/products/ui/widgets/products_body.dart
+++ b/lib/features/products/ui/widgets/products_body.dart
@@ -26,6 +26,7 @@ class ProductsBody extends StatelessWidget {
               child: BlocBuilder<ProductsCubit, ProductsState>(
             buildWhen: (previous, current) =>
                 current is ProductsSuccess ||
+                current is ProductsSearchSuccess ||
                 current is ProductsError ||
                 current is ProductsLoading,
             builder: _buildChild,
@@ -45,17 +46,23 @@ class ProductsBody extends StatelessWidget {
           child:
               Text(state.message, style: AppTextStyles.font20DarkGreyMedium));
     } else if (state is ProductsSuccess) {
-      if (state.products.isEmpty) {
-        return _buildEmptyView(state.selectedProductType);
-      }
-      return _buildGridView(context, state.products);
+      return _buildSuccess(context, state.products, state.selectedProductType);
+    } else if (state is ProductsSearchSuccess) {
+      return _buildSuccess(context, state.products, state.selectedProductType);
     } else {
       return const AnimatedLoadingIndicator();
     }
   }
 
-  AppGridView _buildGridView(
-      BuildContext context, List<ProductModel> products) {
+  Widget _buildSuccess(
+      BuildContext context, List<ProductModel> products, ProductType type) {
+    if (products.isEmpty) {
+      return _buildEmptyView(type);
+    }
+    return _buildGridView(products);
+  }
+
+  AppGridView _buildGridView(List<ProductModel> products) {
     return AppGridView(
       itemCount: products.length,
       crossAxisCount: 4,
@@ -66,10 +73,10 @@ class ProductsBody extends StatelessWidget {
     );
   }
 
-  Widget _buildEmptyView(ProductType? productType) {
+  Widget _buildEmptyView(ProductType productType) {
     return Center(
       child: Text(
-        'No ${productType?.name ?? ProductType.medicines} found',
+        'No ${productType.name} found',
         style: AppTextStyles.font20DarkGreyMedium,
       ),
     );

--- a/lib/features/products/ui/widgets/products_switch_button.dart
+++ b/lib/features/products/ui/widgets/products_switch_button.dart
@@ -21,7 +21,9 @@ class ProductsSwitchButton extends StatelessWidget {
           expandedInsets: EdgeInsets.zero,
           selected: {productType},
           onSelectionChanged: (value) {
-            context.read<ProductsCubit>().toggleProductType(value.first!);
+            context
+                .read<ProductsCubit>()
+                .onToggleProductType(value.first!, context);
           },
           style: _buildStyle,
           segments: _getSegments(productType),

--- a/lib/features/services/logic/cubit/services_cubit.dart
+++ b/lib/features/services/logic/cubit/services_cubit.dart
@@ -1,5 +1,6 @@
 import 'package:bloc/bloc.dart';
 import 'package:el_sharq_clinic/core/helpers/extensions.dart';
+import 'package:el_sharq_clinic/core/logic/cubit/main_cubit.dart';
 import 'package:el_sharq_clinic/core/models/auth_data_model.dart';
 import 'package:el_sharq_clinic/core/theming/assets.dart';
 import 'package:el_sharq_clinic/core/widgets/animated_loading_indicator.dart';
@@ -8,6 +9,7 @@ import 'package:el_sharq_clinic/core/widgets/app_text_button.dart';
 import 'package:el_sharq_clinic/features/services/data/models/service_model.dart';
 import 'package:el_sharq_clinic/features/services/data/repos/services_repo.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
 part 'services_state.dart';
 
@@ -27,17 +29,28 @@ class ServicesCubit extends Cubit<ServicesState> {
   List<ServiceModel> searchResult = [];
 
   // Setup section data
-  void setupSectionData(AuthDataModel authData) {
+  void setupSectionData(AuthDataModel authData, BuildContext context) {
     _authData = authData;
-    _getServices();
+    _getServices(context);
   }
 
   // Get services
-  Future<void> _getServices() async {
+  void _getServices(BuildContext context) async {
     emit(ServicesLoading());
-    servicesList =
-        await _servicesRepo.getServices(_authData!.clinicIndex, null);
+
+    getLoadedServicesIfExist(context);
+
+    if (servicesList.isEmpty) {
+      servicesList =
+          await _servicesRepo.getServices(_authData!.clinicIndex, null);
+    }
     emit(ServicesSuccess(services: servicesList));
+  }
+
+  void getLoadedServicesIfExist(BuildContext context) {
+    if (servicesList.isEmpty) {
+      servicesList = context.read<MainCubit>().servicesList;
+    }
   }
 
   // Save new service
@@ -150,7 +163,7 @@ class ServicesCubit extends Cubit<ServicesState> {
       return;
     }
 
-    emit(ServicesSuccess(services: searchResult));
+    emit(ServicesSearchSuccess(services: searchResult));
   }
 
   void _onSuccessOperation() async {

--- a/lib/features/services/logic/cubit/services_state.dart
+++ b/lib/features/services/logic/cubit/services_state.dart
@@ -11,6 +11,18 @@ final class ServicesLoading extends ServicesState {}
 final class ServicesSuccess extends ServicesState {
   final List<ServiceModel> services;
   ServicesSuccess({required this.services});
+
+  @override
+  void takeAction(BuildContext context) {
+    if (services.isNotEmpty) {
+      context.read<MainCubit>().updateServicesList(services);
+    }
+  }
+}
+
+final class ServicesSearchSuccess extends ServicesState {
+  final List<ServiceModel> services;
+  ServicesSearchSuccess({required this.services});
 }
 
 final class ServicesError extends ServicesState {

--- a/lib/features/services/ui/widgets/service_bloc_listener.dart
+++ b/lib/features/services/ui/widgets/service_bloc_listener.dart
@@ -14,7 +14,8 @@ class ServicesBlocListener extends StatelessWidget {
           current is ServiceAdded ||
           current is ServiceDeleted ||
           current is ServiceUpdated ||
-          current is ServiceError,
+          current is ServiceError ||
+          current is ServicesSuccess,
       listener: (context, state) {
         state.takeAction(context);
       },

--- a/lib/features/services/ui/widgets/services_body.dart
+++ b/lib/features/services/ui/widgets/services_body.dart
@@ -22,9 +22,13 @@ class ServicesBody extends StatelessWidget {
         buildWhen: (_, current) =>
             current is ServicesLoading ||
             current is ServicesSuccess ||
+            current is ServicesSearchSuccess ||
             current is ServicesError,
         builder: (context, state) {
           if (state is ServicesSuccess) {
+            return _buildSuccess(state.services);
+          }
+          if (state is ServicesSearchSuccess) {
             return _buildSuccess(state.services);
           }
           if (state is ServicesError) {


### PR DESCRIPTION
- Created `MainCubti` and `MainState` to be the main cubit that wrap the entire app.
- Added medicines, accessories and services lists to save the sections data even after dispose its cubits to save network resources.
- Refactored the `ProductsCubit` & `ServicesCubit` to store the loaded data from firebase into `MainCubit` lists to use it whenever need.
- Created a new state in `services_state` and `products_state` files to hold the data related to searching process.
- Refactored the `ProductsBlocListener` and `ServicesBlocListener` to listen to the success state and perform its specific action which update the data in the `MainCubit`.
- Update `ServicesBody` and `ProductsBody` bloc builders to update the grid view when the state is search success.