### PR TITLE
Finish Adding New Invoice Feature✅

### DIFF
--- a/lib/core/widgets/app_text_field.dart
+++ b/lib/core/widgets/app_text_field.dart
@@ -1,6 +1,7 @@
 import 'package:el_sharq_clinic/core/theming/app_colors.dart';
 import 'package:el_sharq_clinic/core/theming/app_text_styles.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 
 class AppTextField extends StatelessWidget {
@@ -22,6 +23,7 @@ class AppTextField extends StatelessWidget {
     this.initialValue,
     this.onSaved,
     this.onChanged,
+    this.numeric,
   });
 
   final TextEditingController? controller;
@@ -40,6 +42,7 @@ class AppTextField extends StatelessWidget {
   final String? initialValue;
   final void Function(String? value)? onSaved;
   final void Function(String value)? onChanged;
+  final bool? numeric;
 
   @override
   Widget build(BuildContext context) {
@@ -67,6 +70,11 @@ class AppTextField extends StatelessWidget {
       controller: controller,
       validator: validator,
       onChanged: onChanged,
+      inputFormatters: numeric ?? false
+          ? <TextInputFormatter>[
+              FilteringTextInputFormatter.allow(RegExp(r'[0-9.]'))
+            ]
+          : null,
       onSaved: onSaved,
       initialValue: initialValue,
       style: AppTextStyles.font20DarkGreyMedium,

--- a/lib/features/invoices/data/models/invoice_item_model.dart
+++ b/lib/features/invoices/data/models/invoice_item_model.dart
@@ -1,7 +1,7 @@
 class InvoiceItemModel {
   final String name;
   final double price;
-  final int quantity;
+  final double quantity;
   final String type;
 
   InvoiceItemModel(
@@ -13,8 +13,8 @@ class InvoiceItemModel {
   factory InvoiceItemModel.fromFirestore(Map<String, dynamic> data) {
     return InvoiceItemModel(
       name: data['name'],
-      price: double.parse(data['price']),
-      quantity: int.parse(data['quantity']),
+      price: data['price'],
+      quantity: data['quantity'],
       type: data['type'],
     );
   }
@@ -31,7 +31,7 @@ class InvoiceItemModel {
   InvoiceItemModel copyWith({
     String? name,
     double? price,
-    int? quantity,
+    double? quantity,
     String? type,
   }) {
     return InvoiceItemModel(
@@ -40,5 +40,10 @@ class InvoiceItemModel {
       quantity: quantity ?? this.quantity,
       type: type ?? this.type,
     );
+  }
+
+  @override
+  String toString() {
+    return 'InvoiceItemModel(name: $name, price: $price, quantity: $quantity, type: $type)';
   }
 }

--- a/lib/features/invoices/data/models/invoice_model.dart
+++ b/lib/features/invoices/data/models/invoice_model.dart
@@ -4,7 +4,6 @@ import 'package:el_sharq_clinic/features/invoices/data/models/invoice_item_model
 class InvoiceModel {
   final String id;
   final List<InvoiceItemModel> items;
-  final int numberOfItems;
   final double total;
   final double discount;
   final String date;
@@ -12,7 +11,6 @@ class InvoiceModel {
   const InvoiceModel({
     required this.id,
     required this.items,
-    required this.numberOfItems,
     required this.total,
     required this.discount,
     required this.date,
@@ -21,7 +19,6 @@ class InvoiceModel {
   InvoiceModel copyWith({
     String? id,
     List<InvoiceItemModel>? items,
-    int? numberOfItems,
     double? total,
     double? discount,
     String? date,
@@ -29,7 +26,6 @@ class InvoiceModel {
     return InvoiceModel(
       id: id ?? this.id,
       items: items ?? this.items,
-      numberOfItems: numberOfItems ?? this.numberOfItems,
       total: total ?? this.total,
       discount: discount ?? this.discount,
       date: date ?? this.date,
@@ -40,7 +36,6 @@ class InvoiceModel {
     return {
       'id': id,
       'items': items.map((e) => e.toFirestore()).toList(),
-      'numberOfItems': numberOfItems,
       'total': total,
       'discount': discount,
       'date': date,
@@ -54,9 +49,8 @@ class InvoiceModel {
       items: (data['items'] as List)
           .map((e) => InvoiceItemModel.fromFirestore(e))
           .toList(),
-      numberOfItems: data['numberOfItems'],
-      total: double.parse(data['total'].toString()),
-      discount: double.parse(data['discount'].toString()),
+      total: data['total'],
+      discount: data['discount'],
       date: data['date'],
     );
   }
@@ -66,7 +60,6 @@ class InvoiceModel {
     for (var key in map.keys.toList()) {
       if (map[key] == null ||
           map[key].toString().trim().isEmpty ||
-          map[key] == 0 ||
           key == 'id') {
         map.remove(key);
       }
@@ -78,11 +71,16 @@ class InvoiceModel {
     return [
       id,
       '$total LE',
-      numberOfItems.toString(),
+      items.length.toString(),
       date.substring(0, 10),
       date.substring(11, 19),
       discount.toString(),
       items.map((e) => e.name).toList().join('/n'),
     ];
+  }
+
+  @override
+  String toString() {
+    return 'InvoiceModel(id: $id, items: $items, numberOfItems: ${items.length}, total: $total, discount: $discount, date: $date)';
   }
 }

--- a/lib/features/invoices/data/repos/invoices_repo.dart
+++ b/lib/features/invoices/data/repos/invoices_repo.dart
@@ -19,7 +19,7 @@ class InvoicesRepo {
   }
 
   Future<bool> addNewInvoice(int clinicIndex, InvoiceModel invoiceModel) async {
-    return await _firebaseServices.addItem<InvoiceModel>(
+    return _firebaseServices.addItem<InvoiceModel>(
       collectionName,
       id: invoiceModel.id,
       clinicIndex: clinicIndex,
@@ -30,7 +30,7 @@ class InvoicesRepo {
 
   Future<String?> getLastInvoiceId(
       int clinicIndex, bool descendingOrder) async {
-    return await _firebaseServices.getFirstItemId(
+    return _firebaseServices.getFirstItemId(
       collectionName,
       clinicIndex: clinicIndex,
       descendingOrder: descendingOrder,

--- a/lib/features/invoices/logic/cubit/invoices_state.dart
+++ b/lib/features/invoices/logic/cubit/invoices_state.dart
@@ -1,6 +1,8 @@
 part of 'invoices_cubit.dart';
 
-abstract class InvoicesState {}
+abstract class InvoicesState {
+  void takeAction(BuildContext context) {}
+}
 
 final class InvoicesInitial extends InvoicesState {}
 
@@ -18,14 +20,61 @@ final class InvoicesError extends InvoicesState {
   InvoicesError({required this.message});
 }
 
-final class InvoiceItemsChanged extends InvoicesState {
-  final int numberOfItems;
+final class InvoiceConstruting extends InvoicesState {
+  final InvoiceModel invoiceModel;
 
-  InvoiceItemsChanged({required this.numberOfItems});
+  InvoiceConstruting({required this.invoiceModel});
+}
+
+final class InvoiceConstrutingError extends InvoicesState {
+  final String message;
+
+  InvoiceConstrutingError({required this.message});
 }
 
 final class InvoiceItemTypeChanged extends InvoicesState {
   final int index;
   final String type;
   InvoiceItemTypeChanged({required this.index, required this.type});
+}
+
+final class InvoiceInProgress extends InvoicesState {
+  @override
+  void takeAction(BuildContext context) {
+    showDialog(
+        context: context,
+        barrierDismissible: false,
+        builder: (context) {
+          return const Center(child: AnimatedLoadingIndicator());
+        });
+  }
+}
+
+final class InvoiceSuccessOperation extends InvoicesState {
+  final String message;
+  final int popCount;
+  InvoiceSuccessOperation({required this.message, this.popCount = 1});
+
+  @override
+  void takeAction(BuildContext context) {
+    super.takeAction(context);
+    for (var i = 0; i < popCount; i++) {
+      context.pop();
+    }
+    showDialog(
+      barrierDismissible: false,
+      context: context,
+      builder: (ctx) => AppDialog(
+        title: 'Success',
+        content: message,
+        dialogType: DialogType.success,
+      ),
+    );
+    // Hide success dialog after 2 seconds
+    Future.delayed(const Duration(seconds: 2), () {
+      if (context.mounted) {
+        context.pop();
+      }
+    });
+  }
 }

--- a/lib/features/invoices/ui/invoices_section.dart
+++ b/lib/features/invoices/ui/invoices_section.dart
@@ -1,6 +1,7 @@
 import 'package:el_sharq_clinic/core/helpers/spacing.dart';
 import 'package:el_sharq_clinic/core/widgets/section_action_button.dart';
 import 'package:el_sharq_clinic/core/widgets/section_container.dart';
+import 'package:el_sharq_clinic/features/invoices/ui/widgets/invoices_bloc_listener.dart';
 import 'package:el_sharq_clinic/features/invoices/ui/widgets/invoices_body.dart';
 import 'package:el_sharq_clinic/features/invoices/ui/widgets/invoices_side_sheet.dart';
 import 'package:flutter/material.dart';
@@ -25,6 +26,7 @@ class InvoicesSection extends StatelessWidget {
           children: [
             verticalSpace(50),
             const Expanded(child: InvoicesBody()),
+            const InvoicesBlocListener(),
           ],
         ),
       ),

--- a/lib/features/invoices/ui/widgets/invoice_side_sheet_items_column.dart
+++ b/lib/features/invoices/ui/widgets/invoice_side_sheet_items_column.dart
@@ -1,7 +1,10 @@
+import 'dart:developer';
+
 import 'package:el_sharq_clinic/core/theming/app_colors.dart';
 import 'package:el_sharq_clinic/features/invoices/data/models/invoice_model.dart';
 import 'package:el_sharq_clinic/features/invoices/logic/cubit/invoices_cubit.dart';
 import 'package:el_sharq_clinic/features/invoices/ui/widgets/invoice_side_sheet_item_container.dart';
+import 'package:el_sharq_clinic/features/invoices/ui/widgets/invoice_summary.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
@@ -23,13 +26,24 @@ class InvoiceSideSheetItemsColumn extends StatelessWidget {
     final cubit = cubitContext.read<InvoicesCubit>();
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
-      children: _getItems(cubit),
+      children: [
+        ..._getItems(cubit),
+        InvoiceSummary(
+          total: cubit.invoiceInfo.total,
+          cubit: cubit,
+        ),
+      ],
     );
   }
 
   List<Widget> _getItems(InvoicesCubit cubit) {
+    cubit.itemFormsKeys.forEach((element) {
+      log(element.currentState?.validate().toString() ?? 'Form not valid');
+    });
+    // log(cubit.itemFormsKeys.for.toString());
+
     return List.generate(
-      cubit.numberOfItemsNotifier.value,
+      cubit.invoiceInfo.items.length,
       (index) => Padding(
         padding: const EdgeInsets.only(bottom: 30),
         child: Stack(
@@ -39,9 +53,6 @@ class InvoiceSideSheetItemsColumn extends StatelessWidget {
               itemFormKey: cubit.itemFormsKeys[index],
               editable: editable,
               cubitContext: cubitContext,
-              onSaved: (field, value) {
-                cubit.onSaveInvoiceItemFormField(field, value, index);
-              },
             ),
             if (index != 0 && editable) _buildRemoveButton(index, cubit),
           ],

--- a/lib/features/invoices/ui/widgets/invoice_summary.dart
+++ b/lib/features/invoices/ui/widgets/invoice_summary.dart
@@ -1,0 +1,97 @@
+import 'dart:developer';
+
+import 'package:el_sharq_clinic/core/theming/app_text_styles.dart';
+import 'package:el_sharq_clinic/core/widgets/app_text_field.dart';
+import 'package:el_sharq_clinic/features/invoices/logic/cubit/invoices_cubit.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class InvoiceSummary extends StatelessWidget {
+  const InvoiceSummary({super.key, required this.total, required this.cubit});
+
+  final double total;
+  final InvoicesCubit cubit;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<InvoicesCubit, InvoicesState>(
+      bloc: cubit,
+      buildWhen: (previous, current) => current is InvoiceConstruting,
+      builder: (context, state) {
+        if (state is InvoiceConstruting) {
+          log(state.invoiceModel.toString());
+        }
+        log('InvoiceSummary builder');
+        final summaryMap = _calculateSummary(state);
+        return Row(
+          children: [
+            Expanded(
+              child: AppTextField(
+                hint: 'Discount (LE)',
+                onChanged: (value) {
+                  if (value.isEmpty) {
+                    value = '0';
+                  }
+                  cubit.updateDiscount(double.parse(value));
+                },
+              ),
+            ),
+            const Spacer(),
+            Expanded(
+              flex: 2,
+              child: Column(
+                children: [
+                  _buildSummaryItem('Total', summaryMap['Total']!),
+                  _buildSummaryItem(
+                      'Discount (%)', summaryMap['Discount (%)']!),
+                  _buildSummaryItem('Total after discount',
+                      summaryMap['Total after discount']!),
+                  _buildSummaryItem(
+                      'Number of items', summaryMap['Number of items']!),
+                ],
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Row _buildSummaryItem(String title, num value) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text(
+          title,
+          style: AppTextStyles.font14DarkGreyMedium,
+        ),
+        Text(
+          value.toStringAsFixed(2),
+          style: AppTextStyles.font14DarkGreyMedium,
+        ),
+      ],
+    );
+  }
+
+  Map<String, double> _calculateSummary(InvoicesState state) {
+    final Map<String, double> summaryMap = {
+      'Total': 0.0,
+      'Discount (%)': 0.0,
+      'Total after discount': 0.0,
+      'Number of items': 0.0,
+    };
+    if (state is InvoiceConstruting) {
+      summaryMap['Total'] = state.invoiceModel.total;
+      summaryMap['Discount (%)'] = state.invoiceModel.discount != 0
+          ? state.invoiceModel.discount / summaryMap['Total']! * 100
+          : 0.0;
+
+      summaryMap['Total after discount'] =
+          summaryMap['Total']! - state.invoiceModel.discount;
+      summaryMap['Number of items'] =
+          state.invoiceModel.items.length.toDouble();
+    }
+
+    return summaryMap;
+  }
+}

--- a/lib/features/invoices/ui/widgets/invoices_bloc_listener.dart
+++ b/lib/features/invoices/ui/widgets/invoices_bloc_listener.dart
@@ -1,0 +1,21 @@
+import 'package:el_sharq_clinic/features/invoices/logic/cubit/invoices_cubit.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class InvoicesBlocListener extends StatelessWidget {
+  const InvoicesBlocListener({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<InvoicesCubit, InvoicesState>(
+      listenWhen: (previous, current) =>
+          current is InvoiceConstrutingError ||
+          current is InvoiceSuccessOperation ||
+          current is InvoiceInProgress,
+      listener: (context, state) {
+        state.takeAction(context);
+      },
+      child: const SizedBox.shrink(),
+    );
+  }
+}

--- a/lib/features/invoices/ui/widgets/invoices_side_sheet.dart
+++ b/lib/features/invoices/ui/widgets/invoices_side_sheet.dart
@@ -28,13 +28,16 @@ Future<void> showInvoiceSheet(BuildContext context, String title,
         verticalSpace(50),
         _buildAddItemButtons(context, editable),
         verticalSpace(50),
-        ListenableBuilder(
-          listenable: invoicesCubit.numberOfItemsNotifier,
-          builder: (ctx, child) => InvoiceSideSheetItemsColumn(
-            editable: editable,
-            invoice: invoice,
-            cubitContext: context,
-          ),
+        BlocBuilder<InvoicesCubit, InvoicesState>(
+          bloc: invoicesCubit,
+          buildWhen: (previous, current) => current is InvoiceConstruting,
+          builder: (_, state) {
+            return InvoiceSideSheetItemsColumn(
+              editable: editable,
+              invoice: invoice,
+              cubitContext: context,
+            );
+          },
         ),
         verticalSpace(height * 0.25),
         _buildActionIfNeeded(context, newInvoice),
@@ -61,11 +64,8 @@ _buildActionIfNeeded(BuildContext context, bool newInvoice) {
 
 AppTextButton _buildNewAction(BuildContext context) {
   return AppTextButton(
-    text: 'Save Invoice',
-    width: MediaQuery.sizeOf(context).width,
-    height: 70.h,
-    onPressed: () => context.read<InvoicesCubit>().itemFormsKeys.forEach((key) {
-      key.currentState!.save();
-    }),
-  );
+      text: 'Save Invoice',
+      width: MediaQuery.sizeOf(context).width,
+      height: 70.h,
+      onPressed: () => context.read<InvoicesCubit>().onSaveNewInvoice());
 }


### PR DESCRIPTION
- Refactored `AppTextFormField` to have a numeric param to determine the values that accepted by this field.
- Refactored `InvoiceItemModel` quantity param to be of double type instead of int.
- Remove numberOfItems param from `InvoiceModel`.
- Implemented the adding invoice logic in `InvoicesCubit`.
- Added more states into `InvoicesState` file to handle invoices states.
- Created a `InvoicesBlocListener` widget to listen to invoices states and take an action depends on the current state.
- Handled the logic inside the `InvoiceSideSheetItemContainer` widget.
- Created `InvoiceSummary` widget to hold the summary data of the current invoice.
- Wrapped `InvoiceSideSheetItemsColumn` with BlocBuilder widget to rebuild it depends on a specific state.