### PR TITLE
Finish Invoice Section✅

### DIFF
--- a/lib/features/invoices/data/repos/invoices_repo.dart
+++ b/lib/features/invoices/data/repos/invoices_repo.dart
@@ -1,5 +1,8 @@
+import 'package:el_sharq_clinic/core/models/selable_item_model.dart';
 import 'package:el_sharq_clinic/core/networking/firebase_services.dart';
 import 'package:el_sharq_clinic/features/invoices/data/models/invoice_model.dart';
+import 'package:el_sharq_clinic/features/products/data/models/product_model.dart';
+import 'package:el_sharq_clinic/features/services/data/models/service_model.dart';
 
 class InvoicesRepo {
   final FirebaseServices _firebaseServices;
@@ -43,5 +46,34 @@ class InvoicesRepo {
       clinicIndex: clinicIndex,
       descendingOrder: descendingOrder,
     );
+  }
+
+  Future<List<List<SelableItemModel>>> loadSelableItemsLists(
+      int clinicIndex) async {
+    final result = await Future.wait([
+      _firebaseServices.getItems<ServiceModel>(
+        'services',
+        clinicIndex: clinicIndex,
+        fromFirestore: ServiceModel.fromFirestore,
+        descendingOrder: false,
+        limit: -1,
+      ),
+      _firebaseServices.getItems<ProductModel>(
+        'medicines',
+        clinicIndex: clinicIndex,
+        fromFirestore: ProductModel.fromFirestore,
+        descendingOrder: false,
+        limit: -1,
+      ),
+      _firebaseServices.getItems<ProductModel>(
+        'accessories',
+        clinicIndex: clinicIndex,
+        fromFirestore: ProductModel.fromFirestore,
+        descendingOrder: false,
+        limit: -1,
+      ),
+    ]);
+
+    return result;
   }
 }

--- a/lib/features/invoices/logic/cubit/invoices_cubit.dart
+++ b/lib/features/invoices/logic/cubit/invoices_cubit.dart
@@ -47,17 +47,42 @@ class InvoicesCubit extends Cubit<InvoicesState> {
   // Get Invoices Functions
   void setupSectionData(
       AuthDataModel authenticationData, BuildContext context) {
-    _setupSelableItemsListsData(context);
     _setAuthData(authenticationData);
+    _setupSelableItemsListsData(context);
     _getPaginatedInvoices();
   }
 
-  void _setupSelableItemsListsData(BuildContext context) {
-    servicesList = context.read<MainCubit>().servicesList;
+  void _setupSelableItemsListsData(BuildContext context) async {
+    final MainCubit mainCubit = context.read<MainCubit>();
+    servicesList = mainCubit.servicesList;
+    medicinesList = mainCubit.medicinesList;
+    accessoriesList = mainCubit.accessorieList;
+    if (servicesList.isEmpty ||
+        medicinesList.isEmpty ||
+        accessoriesList.isEmpty) {
+      await loadSelableItemsLists();
+      updateSelableItemsListsInMainCubit(mainCubit);
+    }
+  }
 
-    medicinesList = context.read<MainCubit>().medicinesList;
+  Future<void> loadSelableItemsLists() async {
+    final result =
+        await _invoicesRepo.loadSelableItemsLists(authData!.clinicIndex);
+    servicesList = result[0] as List<ServiceModel>;
+    medicinesList = result[1] as List<ProductModel>;
+    accessoriesList = result[2] as List<ProductModel>;
+  }
 
-    accessoriesList = context.read<MainCubit>().accessorieList;
+  void updateSelableItemsListsInMainCubit(MainCubit cubit) {
+    cubit.updateServicesList(
+      servicesList,
+    );
+    cubit.updateMedicinesList(
+      medicinesList,
+    );
+    cubit.updateAccessoriesList(
+      accessoriesList,
+    );
   }
 
   void _setAuthData(AuthDataModel authenticationData) {

--- a/lib/features/invoices/ui/invoices_section.dart
+++ b/lib/features/invoices/ui/invoices_section.dart
@@ -19,11 +19,19 @@ class InvoicesSection extends StatelessWidget {
     return SectionContainer(
       title: 'Invoices',
       actions: [
-        SectionActionButton(
-          newText: 'New Invoice',
-          onNewPressed: () => showInvoiceSheet(context, 'New Invoice'),
-          onDeletePressed: () => _onDeleteDoctors(context),
-          valueNotifier: context.read<InvoicesCubit>().showDeleteButtonNotifier,
+        BlocBuilder<InvoicesCubit, InvoicesState>(
+          builder: (context, state) {
+            if (state is InvoicesLoading) {
+              return const SizedBox.shrink();
+            }
+            return SectionActionButton(
+              newText: 'New Invoice',
+              onNewPressed: () => showInvoiceSheet(context, 'New Invoice'),
+              onDeletePressed: () => _onDeleteDoctors(context),
+              valueNotifier:
+                  context.read<InvoicesCubit>().showDeleteButtonNotifier,
+            );
+          },
         ),
       ],
       child: Expanded(


### PR DESCRIPTION
- Retrieved the sealable items data list if empty (Services, Medicines, Accessorize) when the user get in the Invoices section however these data lists are empty.
- Wrapped the `SectionActionButton` with bloc builder widget to hide it in loading state.