### PR TITLE
Finish UI Logic of Settings Section✅

### DIFF
--- a/devtools_options.yaml
+++ b/devtools_options.yaml
@@ -1,0 +1,3 @@
+description: This file stores settings for Dart & Flutter DevTools.
+documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
+extensions:

--- a/lib/core/di/dependency_injection.dart
+++ b/lib/core/di/dependency_injection.dart
@@ -20,6 +20,8 @@ import 'package:el_sharq_clinic/features/products/data/repos/products_repo.dart'
 import 'package:el_sharq_clinic/features/products/logic/cubit/products_cubit.dart';
 import 'package:el_sharq_clinic/features/services/data/repos/services_repo.dart';
 import 'package:el_sharq_clinic/features/services/logic/cubit/services_cubit.dart';
+import 'package:el_sharq_clinic/features/settings/data/repos/settings_repo.dart';
+import 'package:el_sharq_clinic/features/settings/logic/cubit/settings_cubit.dart';
 import 'package:get_it/get_it.dart';
 
 GetIt getIt = GetIt.instance;
@@ -43,6 +45,7 @@ void setupGetIt() {
   getIt.registerFactory<ServicesCubit>(() => ServicesCubit(getIt()));
   getIt.registerFactory<ProductsCubit>(() => ProductsCubit(getIt()));
   getIt.registerFactory<InvoicesCubit>(() => InvoicesCubit(getIt()));
+  getIt.registerFactory<SettingsCubit>(() => SettingsCubit(getIt()));
   getIt.registerFactory<MainCubit>(() => MainCubit());
 
   // Repos
@@ -55,4 +58,5 @@ void setupGetIt() {
   getIt.registerLazySingleton<ServicesRepo>(() => ServicesRepo(getIt()));
   getIt.registerLazySingleton<ProductsRepo>(() => ProductsRepo(getIt()));
   getIt.registerLazySingleton<InvoicesRepo>(() => InvoicesRepo(getIt()));
+  getIt.registerLazySingleton<SettingsRepo>(() => SettingsRepo(getIt()));
 }

--- a/lib/core/models/auth_data_model.dart
+++ b/lib/core/models/auth_data_model.dart
@@ -1,12 +1,77 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:el_sharq_clinic/features/auth/data/local/models/user_model.dart';
 
 class AuthDataModel {
   final UserModel userModel;
   final int clinicIndex;
   final String clinicName;
+  final String language;
+  final String theme;
+  final double lowStockLimit;
 
   AuthDataModel(
       {required this.clinicIndex,
       required this.userModel,
-      required this.clinicName});
+      required this.clinicName,
+      required this.language,
+      required this.theme,
+      required this.lowStockLimit});
+
+  AuthDataModel copyWith({
+    int? clinicIndex,
+    UserModel? userModel,
+    String? clinicName,
+    String? language,
+    String? theme,
+    double? lowStockLimit,
+  }) {
+    return AuthDataModel(
+      clinicIndex: clinicIndex ?? this.clinicIndex,
+      userModel: userModel ?? this.userModel,
+      clinicName: clinicName ?? this.clinicName,
+      language: language ?? this.language,
+      theme: theme ?? this.theme,
+      lowStockLimit: lowStockLimit ?? this.lowStockLimit,
+    );
+  }
+
+  Map<String, dynamic> toFirestore() {
+    return {
+      'clinicIndex': clinicIndex,
+      'userModel': userModel.toFirestore(),
+      'clinicName': clinicName,
+      'language': language,
+      'theme': theme,
+      'lowStockLimit': lowStockLimit,
+    };
+  }
+
+  factory AuthDataModel.fromFirestore(QueryDocumentSnapshot<Object?> doc) {
+    return AuthDataModel(
+      clinicIndex: doc['clinicIndex'],
+      userModel: UserModel.fromFirestore(doc['userModel']),
+      clinicName: doc['clinicName'],
+      language: doc['language'],
+      theme: doc['theme'],
+      lowStockLimit: doc['lowStockLimit'],
+    );
+  }
+
+  @override
+  String toString() {
+    return 'AuthDataModel(clinicIndex: $clinicIndex, userModel: $userModel, clinicName: $clinicName, language: $language, theme: $theme, lowStockLimit: $lowStockLimit)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is AuthDataModel &&
+        other.clinicIndex == clinicIndex &&
+        other.userModel == userModel &&
+        other.clinicName == clinicName &&
+        other.language == language &&
+        other.theme == theme &&
+        other.lowStockLimit == lowStockLimit;
+  }
 }

--- a/lib/core/widgets/app_text_button.dart
+++ b/lib/core/widgets/app_text_button.dart
@@ -13,7 +13,8 @@ class AppTextButton extends StatelessWidget {
       this.filled = true,
       this.icon,
       this.color,
-      this.textStyle});
+      this.textStyle,
+      this.enabled = true});
 
   final String text;
   final void Function() onPressed;
@@ -23,6 +24,7 @@ class AppTextButton extends StatelessWidget {
   final IconData? icon;
   final Color? color;
   final TextStyle? textStyle;
+  final bool enabled;
 
   @override
   Widget build(BuildContext context) {
@@ -32,7 +34,7 @@ class AppTextButton extends StatelessWidget {
   TextButton _buildTextButton() {
     return TextButton(
       style: _buildButtonStyle(),
-      onPressed: onPressed,
+      onPressed: enabled ? onPressed : null,
       child: FittedBox(
         fit: BoxFit.scaleDown,
         child: Text(text,
@@ -48,7 +50,7 @@ class AppTextButton extends StatelessWidget {
   TextButton _buildTextButtonWithIcon() {
     return TextButton.icon(
       style: _buildButtonStyle(),
-      onPressed: onPressed,
+      onPressed: enabled ? onPressed : null,
       icon: Icon(
         icon,
         color: AppColors.white,
@@ -71,7 +73,11 @@ class AppTextButton extends StatelessWidget {
         width ?? 300.w,
         height ?? 50.h,
       ),
-      backgroundColor: filled! ? color ?? AppColors.blue : AppColors.white,
+      backgroundColor: enabled
+          ? filled!
+              ? color ?? AppColors.blue
+              : AppColors.white
+          : AppColors.darkGrey.withOpacity(0.5),
       padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(10),

--- a/lib/features/auth/data/local/models/user_model.dart
+++ b/lib/features/auth/data/local/models/user_model.dart
@@ -21,10 +21,27 @@ class UserModel {
     );
   }
 
+  factory UserModel.empty() {
+    return UserModel(
+      id: '',
+      userName: '',
+      password: '',
+    );
+  }
+
   Map<String, dynamic> toFirestore() {
     return {
       'userName': userName,
       'password': password,
     };
+  }
+
+  bool get isEmpty {
+    return id.isEmpty && userName.isEmpty && password.isEmpty;
+  }
+
+  @override
+  String toString() {
+    return 'UserModel(id: $id, userName: $userName, password: $password)';
   }
 }

--- a/lib/features/auth/data/local/repos/auth_repo.dart
+++ b/lib/features/auth/data/local/repos/auth_repo.dart
@@ -1,5 +1,4 @@
-import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:el_sharq_clinic/features/auth/data/local/models/user_model.dart';
+import 'package:el_sharq_clinic/core/models/auth_data_model.dart';
 import 'package:el_sharq_clinic/features/auth/data/remote/auth_firebase_services.dart';
 
 class AuthRepo {
@@ -7,7 +6,7 @@ class AuthRepo {
 
   AuthRepo(this._authFirebaseServices);
 
-  Future<QueryDocumentSnapshot<UserModel>?> openWithUserNameAndPassword(
+  Future<AuthDataModel?> openWithUserNameAndPassword(
       int clinicIndex, String userName, String password) async {
     return await _authFirebaseServices.openWithUserNameAndPassword(
         clinicIndex, userName, password);

--- a/lib/features/auth/logic/cubit/auth_cubit.dart
+++ b/lib/features/auth/logic/cubit/auth_cubit.dart
@@ -1,3 +1,5 @@
+import 'dart:developer';
+
 import 'package:bloc/bloc.dart';
 import 'package:el_sharq_clinic/core/helpers/constants.dart';
 import 'package:el_sharq_clinic/core/models/auth_data_model.dart';
@@ -31,16 +33,14 @@ class AuthCubit extends Cubit<AuthState> {
           .then(
         (value) {
           if (value != null) {
-            emit(AuthSuccess(AuthDataModel(
-                clinicIndex: AppConstant.clinicsList.indexOf(selectedClinic),
-                userModel: value.data(),
-                clinicName: selectedClinic)));
-            return value.data();
+            log(value.toString());
+            emit(AuthSuccess(
+              value,
+            ));
+          } else {
+            emit(AuthFailure(
+                'Invalid username or password for the selected clinic'));
           }
-          emit(AuthFailure(
-              'Invalid username or password for the selected clinic'));
-
-          return null;
         },
       );
     }

--- a/lib/features/dashboard/ui/widgets/sales_pie_chart.dart
+++ b/lib/features/dashboard/ui/widgets/sales_pie_chart.dart
@@ -55,9 +55,7 @@ class _SalesPieChartState extends State<SalesPieChart> {
       final fontSize = isTouched ? 14.sp : 16.sp;
       final radius = isTouched ? 105.r : 85.r;
       final Color color = widget.items[i].color;
-      final double value = isTouched
-          ? widget.items[i].value
-          : double.parse(widget.items[i].percentage.toStringAsFixed(1));
+      final double value = widget.items[i].value;
       final String displayedValue = isTouched
           ? '${widget.items[i].value.toStringAsFixed(0)} LE'
           : '${widget.items[i].percentage.toStringAsFixed(1)}%';

--- a/lib/features/home/ui/home_layout.dart
+++ b/lib/features/home/ui/home_layout.dart
@@ -18,6 +18,7 @@ import 'package:el_sharq_clinic/features/products/logic/cubit/products_cubit.dar
 import 'package:el_sharq_clinic/features/products/ui/products_section.dart';
 import 'package:el_sharq_clinic/features/services/logic/cubit/services_cubit.dart';
 import 'package:el_sharq_clinic/features/services/ui/services_section.dart';
+import 'package:el_sharq_clinic/features/settings/logic/cubit/settings_cubit.dart';
 import 'package:el_sharq_clinic/features/settings/ui/settings_section.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -103,7 +104,11 @@ class _HomeLayoutState extends State<HomeLayout> {
               ..setupSectionData(widget.authData, context),
             child: const InvoicesSection(),
           ),
-      (context) => const SettingsSection(),
+      (context) => BlocProvider<SettingsCubit>(
+            create: (context) =>
+                getIt<SettingsCubit>()..setupSectionData(widget.authData),
+            child: const SettingsSection(),
+          ),
     ];
   }
 }

--- a/lib/features/invoices/ui/widgets/invoice_side_sheet_item_container.dart
+++ b/lib/features/invoices/ui/widgets/invoice_side_sheet_item_container.dart
@@ -148,6 +148,7 @@ class _InvoiceSideSheetItemContainerState
                         enabled: widget.editable,
                         controller: totalPriceController,
                         maxWidth: double.infinity,
+                        readOnly: true,
                         hint: 'Total: ',
                       ),
                     ),

--- a/lib/features/settings/data/repos/settings_repo.dart
+++ b/lib/features/settings/data/repos/settings_repo.dart
@@ -1,0 +1,7 @@
+import 'package:el_sharq_clinic/core/networking/firebase_services.dart';
+
+class SettingsRepo {
+  final FirebaseServices _firebaseServices;
+
+  SettingsRepo(this._firebaseServices);
+}

--- a/lib/features/settings/logic/cubit/settings_cubit.dart
+++ b/lib/features/settings/logic/cubit/settings_cubit.dart
@@ -1,0 +1,59 @@
+import 'package:bloc/bloc.dart';
+import 'package:el_sharq_clinic/core/models/auth_data_model.dart';
+import 'package:el_sharq_clinic/features/settings/data/repos/settings_repo.dart';
+import 'package:flutter/material.dart';
+
+part 'settings_state.dart';
+
+class SettingsCubit extends Cubit<SettingsState> {
+  final SettingsRepo _settingsRepo;
+  SettingsCubit(this._settingsRepo) : super(SettingsInitial());
+
+  // Variables
+  AuthDataModel? authData;
+  AuthDataModel? newAuthData;
+  ValueNotifier<bool> saveButtonState = ValueNotifier<bool>(false);
+
+  // Methods
+  void setupSectionData(AuthDataModel authData) {
+    this.authData = authData;
+    newAuthData = authData;
+  }
+
+  void changeLanguage(String language) {
+    emit(SettingsInitial());
+    newAuthData = newAuthData!.copyWith(language: language);
+    if (newAuthData != authData) {
+      emit(SettingsUpdated());
+      saveButtonState.value = true;
+    }
+    determineSaveButtonState();
+  }
+
+  void changeTheme(String theme) {
+    emit(SettingsInitial());
+    newAuthData = newAuthData!.copyWith(theme: theme);
+    if (newAuthData != authData) {
+      emit(SettingsUpdated());
+      saveButtonState.value = true;
+    }
+    determineSaveButtonState();
+  }
+
+  void changeLowStockLimit(double lowStockLimit) {
+    emit(SettingsInitial());
+    newAuthData = newAuthData!.copyWith(lowStockLimit: lowStockLimit);
+    if (newAuthData != authData) {
+      emit(SettingsUpdated());
+    }
+    determineSaveButtonState();
+  }
+
+  void determineSaveButtonState() {
+    if (newAuthData != authData) {
+      saveButtonState.value = true;
+    } else {
+      saveButtonState.value = false;
+    }
+  }
+}

--- a/lib/features/settings/logic/cubit/settings_state.dart
+++ b/lib/features/settings/logic/cubit/settings_state.dart
@@ -1,0 +1,7 @@
+part of 'settings_cubit.dart';
+
+abstract class SettingsState {}
+
+final class SettingsInitial extends SettingsState {}
+
+final class SettingsUpdated extends SettingsState {}

--- a/lib/features/settings/ui/settings_section.dart
+++ b/lib/features/settings/ui/settings_section.dart
@@ -1,15 +1,35 @@
 import 'package:el_sharq_clinic/core/helpers/spacing.dart';
+import 'package:el_sharq_clinic/core/widgets/app_text_button.dart';
 import 'package:el_sharq_clinic/core/widgets/section_container.dart';
+import 'package:el_sharq_clinic/features/settings/logic/cubit/settings_cubit.dart';
 import 'package:el_sharq_clinic/features/settings/ui/widgets/settings_body.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 
 class SettingsSection extends StatelessWidget {
   const SettingsSection({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final ValueNotifier<bool> saveButtonState =
+        context.read<SettingsCubit>().saveButtonState;
+
     return SectionContainer(
       title: 'Settings',
+      actions: [
+        ListenableBuilder(
+          listenable: saveButtonState,
+          builder: (ctx, child) => AppTextButton(
+            text: 'Save',
+            width: 200.w,
+            height: 55.h,
+            icon: Icons.save,
+            onPressed: () {},
+            enabled: saveButtonState.value,
+          ),
+        )
+      ],
       child: Expanded(
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/features/settings/ui/widgets/settings_body.dart
+++ b/lib/features/settings/ui/widgets/settings_body.dart
@@ -1,9 +1,13 @@
+import 'dart:developer';
+
 import 'package:el_sharq_clinic/core/helpers/spacing.dart';
 import 'package:el_sharq_clinic/core/theming/app_text_styles.dart';
 import 'package:el_sharq_clinic/core/widgets/app_text_field.dart';
 import 'package:el_sharq_clinic/core/widgets/section_details_container.dart';
+import 'package:el_sharq_clinic/features/settings/logic/cubit/settings_cubit.dart';
 import 'package:el_sharq_clinic/features/settings/ui/widgets/settings_segmented_button.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 
 class SettingsBody extends StatelessWidget {
@@ -11,48 +15,65 @@ class SettingsBody extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final authData = context.read<SettingsCubit>().authData!;
+    log(authData.theme.toString());
     return SectionDetailsContainer(
       padding: EdgeInsets.symmetric(vertical: 50.h, horizontal: 40.w),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.end,
-        children: [
-          _buildSegmentedButtonListTile('Language', ['English', 'Arabic']),
-          verticalSpace(40.h),
-          _buildSegmentedButtonListTile('Theme', ['Light', 'Dark']),
-          verticalSpace(40.h),
-          ListTile(
-            contentPadding: EdgeInsets.zero,
-            title: const Text(
-              'Low Stock Limit',
-              style: AppTextStyles.font24DarkGreyMedium,
+      child: SingleChildScrollView(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.end,
+          children: [
+            _buildSegmentedButtonListTile(
+              'Language',
+              ['English', 'Arabic'],
+              authData.language,
+              context,
+              onLanguageChanged,
             ),
-            subtitle: Text(
-              'The default low stock limit is 5',
-              style: AppTextStyles.font16DarkGreyMedium.copyWith(
-                color: Colors.grey,
+            verticalSpace(40.h),
+            _buildSegmentedButtonListTile(
+              'Theme',
+              ['Light', 'Dark'],
+              authData.theme,
+              context,
+              onThemeChanged,
+            ),
+            verticalSpace(40.h),
+            ListTile(
+              contentPadding: EdgeInsets.zero,
+              title: const Text(
+                'Low Stock Limit',
+                style: AppTextStyles.font24DarkGreyMedium,
+              ),
+              subtitle: Text(
+                'The default low stock limit is 5',
+                style: AppTextStyles.font16DarkGreyMedium.copyWith(
+                  color: Colors.grey,
+                ),
+              ),
+              trailing: AppTextField(
+                maxHeight: 50.h,
+                initialValue: authData.lowStockLimit.toString(),
+                insideHint: true,
+                hint: 'Limit',
+                numeric: true,
+                onChanged: (value) => onLowStockLimitChanged(value, context),
               ),
             ),
-            trailing: AppTextField(
-              maxHeight: 50.h,
-              initialValue: '5',
-              insideHint: true,
-              hint: 'Limit',
-              numeric: true,
-            ),
-          ),
-          verticalSpace(40.h),
-          const Divider(),
-          verticalSpace(10.h),
-          _buildSideSheetListTile('Change Password', () {}),
-          verticalSpace(10.h),
-          const Divider(),
-          verticalSpace(10.h),
-          _buildSideSheetListTile('Change Clinic Name', () {}),
-          verticalSpace(10.h),
-          const Divider(),
-          verticalSpace(10.h),
-          _buildSideSheetListTile('Add User Account', () {}),
-        ],
+            verticalSpace(40.h),
+            const Divider(),
+            verticalSpace(10.h),
+            _buildSideSheetListTile('Change Password', () {}),
+            verticalSpace(10.h),
+            const Divider(),
+            verticalSpace(10.h),
+            _buildSideSheetListTile('Change Clinic Name', () {}),
+            verticalSpace(10.h),
+            const Divider(),
+            verticalSpace(10.h),
+            _buildSideSheetListTile('Add User Account', () {}),
+          ],
+        ),
       ),
     );
   }
@@ -69,21 +90,41 @@ class SettingsBody extends StatelessWidget {
     );
   }
 
-  ListTile _buildSegmentedButtonListTile(String title, List<String> values) {
+  ListTile _buildSegmentedButtonListTile(
+    String title,
+    List<String> values,
+    String selected,
+    BuildContext context,
+    Function(String, BuildContext) onSelectionChanged,
+  ) {
     return ListTile(
       contentPadding: EdgeInsets.zero,
       title: Text(
         title,
         style: AppTextStyles.font24DarkGreyMedium,
       ),
-      trailing: SizedBox(
-        width: 300.w,
-        height: 50.h,
+      trailing: ConstrainedBox(
+        constraints: BoxConstraints(maxWidth: 300.w, maxHeight: 100.h),
         child: SettingsSegmentedButton<String>(
-          selected: values.first,
+          onSelectionChanged: (value) => onSelectionChanged(value, context),
+          selected: selected,
           titles: values,
         ),
       ),
     );
+  }
+
+  void onLanguageChanged(String value, BuildContext context) {
+    context.read<SettingsCubit>().changeLanguage(value);
+  }
+
+  void onThemeChanged(String value, BuildContext context) {
+    context.read<SettingsCubit>().changeTheme(value);
+  }
+
+  void onLowStockLimitChanged(String value, BuildContext context) {
+    context
+        .read<SettingsCubit>()
+        .changeLowStockLimit(double.tryParse(value) ?? 0);
   }
 }

--- a/lib/features/settings/ui/widgets/settings_segmented_button.dart
+++ b/lib/features/settings/ui/widgets/settings_segmented_button.dart
@@ -3,22 +3,46 @@ import 'package:el_sharq_clinic/core/theming/app_text_styles.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 
-class SettingsSegmentedButton<T> extends StatelessWidget {
+class SettingsSegmentedButton<T> extends StatefulWidget {
   const SettingsSegmentedButton(
-      {super.key, required this.titles, required this.selected});
+      {super.key,
+      required this.titles,
+      required this.selected,
+      required this.onSelectionChanged});
 
   final T selected;
   final List<T> titles;
+  final Function(T value) onSelectionChanged;
+
+  @override
+  State<SettingsSegmentedButton<T>> createState() =>
+      _SettingsSegmentedButtonState<T>();
+}
+
+class _SettingsSegmentedButtonState<T>
+    extends State<SettingsSegmentedButton<T>> {
+  late T selected;
+
+  @override
+  void initState() {
+    super.initState();
+    selected = widget.selected;
+  }
 
   @override
   Widget build(BuildContext context) {
     return SegmentedButton<T>(
-      // expandedInsets: EdgeInsets.zero,
       selectedIcon: const SizedBox.shrink(),
-      onSelectionChanged: (value) {},
+      onSelectionChanged: (value) {
+        widget.onSelectionChanged(value.first);
+        setState(() {
+          selected = value.first;
+        });
+      },
       selected: {selected},
-      segments: _getSegments(titles),
+      segments: _getSegments(widget.titles),
       style: _buildStyle,
+      expandedInsets: EdgeInsets.zero,
     );
   }
 
@@ -44,12 +68,12 @@ class SettingsSegmentedButton<T> extends StatelessWidget {
       selectedBackgroundColor: AppColors.blue.withOpacity(0.85),
       selectedForegroundColor: AppColors.white,
       side: const BorderSide(color: AppColors.darkGrey, width: 1),
+      maximumSize: Size(300.w, 100.h),
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.all(
           Radius.circular(8),
         ),
       ),
-      padding: EdgeInsets.symmetric(horizontal: 20.w, vertical: 15.h),
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: b1595874fbc8f7a50da90f5d8f327bb0bfd6a95dc906c390efe991540c3b54aa
+      sha256: "9371d13b8ee442e3bfc08a24e3a1b3742c839abbfaf5eef11b79c4b862c89bf7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.40"
+    version: "1.3.41"
   archive:
     dependency: transitive
     description:
@@ -85,26 +85,26 @@ packages:
     dependency: "direct main"
     description:
       name: cloud_firestore
-      sha256: a31eec60eadaa859f0677bf661d9f86ed15961c716512f64884e59edcb341472
+      sha256: "0af4f1e0b7f82a2082ad2c886b042595d85c7641616688609dd999d33aeef850"
       url: "https://pub.dev"
     source: hosted
-    version: "5.2.1"
+    version: "5.4.0"
   cloud_firestore_platform_interface:
     dependency: transitive
     description:
       name: cloud_firestore_platform_interface
-      sha256: "3224e6158441c8897325e74f9971140cde2c85ee75a26704407a91b969b50829"
+      sha256: "6e82bcaf2b8e33f312dfc7c5e5855376fee538467dd6e58dc41bd13996ff5d64"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.1"
+    version: "6.4.0"
   cloud_firestore_web:
     dependency: transitive
     description:
       name: cloud_firestore_web
-      sha256: c1312945cb7dd55921bcc10445f6c9a494bc04104b7d0821c3ed577b970ab088
+      sha256: "38aec6ed732980dea6eec192a25fb55665137edc5c356603d8dc26ff5971f4d8"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.1"
+    version: "4.2.0"
   collection:
     dependency: transitive
     description:
@@ -165,26 +165,26 @@ packages:
     dependency: "direct main"
     description:
       name: firebase_core
-      sha256: "3187f4f8e49968573fd7403011dca67ba95aae419bc0d8131500fae160d94f92"
+      sha256: "06537da27db981947fa535bb91ca120b4e9cb59cb87278dbdde718558cafc9ff"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.0"
+    version: "3.4.0"
   firebase_core_platform_interface:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
-      sha256: "3c3a1e92d6f4916c32deea79c4a7587aa0e9dbbe5889c7a16afcf005a485ee02"
+      sha256: f7d7180c7f99babd4b4c517754d41a09a4943a0f7a69b65c894ca5c68ba66315
       url: "https://pub.dev"
     source: hosted
-    version: "5.2.0"
+    version: "5.2.1"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
-      sha256: e8d1e22de72cb21cdcfc5eed7acddab3e99cd83f3b317f54f7a96c32f25fd11e
+      sha256: "362e52457ed2b7b180964769c1e04d1e0ea0259fdf7025fdfedd019d4ae2bd88"
       url: "https://pub.dev"
     source: hosted
-    version: "2.17.4"
+    version: "2.17.5"
   firedart:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,10 +28,10 @@ environment:
 # the latest version available on pub.dev. To see which dependencies have newer
 # versions available, run `flutter pub outdated`.
 dependencies:
-  cloud_firestore: ^5.2.1
+  cloud_firestore: ^5.4.0
   cupertino_icons: ^1.0.8
   data_table_2: ^2.5.15
-  firebase_core: ^3.3.0
+  firebase_core: ^3.4.0
   firedart: ^0.9.8
   flutter:
     sdk: flutter


### PR DESCRIPTION
- Created the `SettingsCubit` and `SettingsRepo` then add them into DI file.
- Refactored the `AppTextButton` to be able to make it enabled or disabled.
- Refactored the `UserModel` to be able to initiate an empty object form it and be able to determine that this object is an empty object or not.
- Refactored the `openWithUsernameAndPassword` method in the `AuthFirebaseServices` class to return an `AuthDataModel` instead of `QueryDocumentSnapshot<UserModel>`.
- Wrapped the `SettingsSection` with `BlocProvider<SettingsCubit>` in `HomeLayout => _getDrawerItems` method.