### PR TITLE
Finish Settings Firebase Logic✅

### DIFF
--- a/lib/core/logic/cubit/main_cubit.dart
+++ b/lib/core/logic/cubit/main_cubit.dart
@@ -6,7 +6,7 @@ import 'package:el_sharq_clinic/features/services/data/models/service_model.dart
 part 'main_state.dart';
 
 class MainCubit extends Cubit<MainState> {
-  MainCubit() : super(MainInitial());
+  MainCubit() : super(MainInitial(authDataModel: AuthDataModel.empty()));
 
   // Variables
   AuthDataModel authData = AuthDataModel.empty();
@@ -16,6 +16,11 @@ class MainCubit extends Cubit<MainState> {
   List<ServiceModel> servicesList = [];
 
   // Functions
+  void setupInitialData(AuthDataModel authData) {
+    this.authData = authData;
+    emit(MainInitial(authDataModel: authData));
+  }
+
   void updateMedicinesList(List<ProductModel> medicines) {
     medicinesList = medicines;
   }
@@ -30,5 +35,6 @@ class MainCubit extends Cubit<MainState> {
 
   void updateAuthData(AuthDataModel authData) {
     this.authData = authData;
+    emit(MainUpdated(authDataModel: authData));
   }
 }

--- a/lib/core/logic/cubit/main_state.dart
+++ b/lib/core/logic/cubit/main_state.dart
@@ -1,5 +1,15 @@
 part of 'main_cubit.dart';
 
-abstract class MainState {}
+abstract class MainState {
+  AuthDataModel authDataModel;
 
-final class MainInitial extends MainState {}
+  MainState({required this.authDataModel});
+}
+
+final class MainInitial extends MainState {
+  MainInitial({required super.authDataModel});
+}
+
+final class MainUpdated extends MainState {
+  MainUpdated({required super.authDataModel});
+}

--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -24,10 +24,9 @@ class AppRouter {
       case AppRoutes.home:
         return MaterialPageRoute(
           builder: (_) => BlocProvider<MainCubit>(
-            create: (context) => getIt<MainCubit>(),
-            child: HomeLayout(
-              authData: arguments as AuthDataModel,
-            ),
+            create: (context) => getIt<MainCubit>()
+              ..setupInitialData(arguments as AuthDataModel),
+            child: const HomeLayout(),
           ),
         );
       default:

--- a/lib/core/widgets/app_dialog.dart
+++ b/lib/core/widgets/app_dialog.dart
@@ -61,7 +61,7 @@ class AppDialog extends StatelessWidget {
               child: Text(
                 content,
                 textAlign: TextAlign.center,
-                style: AppTextStyles.font16DarkGreyMedium,
+                style: AppTextStyles.font20DarkGreyMedium,
               ),
             ),
             if (action != null) const Spacer(),

--- a/lib/core/widgets/password_dialog.dart
+++ b/lib/core/widgets/password_dialog.dart
@@ -8,8 +8,12 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 
 class PasswordDialog extends StatefulWidget {
   const PasswordDialog(
-      {super.key, required this.actionTitle, required this.onActionPressed});
+      {super.key,
+      required this.actionTitle,
+      required this.onActionPressed,
+      this.title});
 
+  final String? title;
   final String actionTitle;
   final void Function(String password) onActionPressed;
 
@@ -42,7 +46,7 @@ class _PasswordDialogState extends State<PasswordDialog> {
               height: 40.h,
               alignment: Alignment.center,
               child: Text(
-                'Enter your password',
+                widget.title ?? 'Enter your password',
                 style: AppTextStyles.font16DarkGreyMedium.copyWith(
                   color: AppColors.white,
                 ),

--- a/lib/features/auth/data/local/models/user_model.dart
+++ b/lib/features/auth/data/local/models/user_model.dart
@@ -4,11 +4,13 @@ class UserModel {
   final String id;
   final String userName;
   final String password;
+  final UserType role;
 
   UserModel({
     required this.id,
     required this.userName,
     required this.password,
+    required this.role,
   });
 
   factory UserModel.fromFirestore(
@@ -18,6 +20,8 @@ class UserModel {
       id: snapshot.id,
       userName: data['userName'],
       password: data['password'],
+      role:
+          UserType.values.firstWhere((element) => element.name == data['role']),
     );
   }
 
@@ -26,6 +30,21 @@ class UserModel {
       id: '',
       userName: '',
       password: '',
+      role: UserType.user,
+    );
+  }
+
+  UserModel copyWith({
+    String? id,
+    String? userName,
+    String? password,
+    UserType? role,
+  }) {
+    return UserModel(
+      id: id ?? this.id,
+      userName: userName ?? this.userName,
+      password: password ?? this.password,
+      role: role ?? this.role,
     );
   }
 
@@ -33,6 +52,7 @@ class UserModel {
     return {
       'userName': userName,
       'password': password,
+      'role': role.name,
     };
   }
 
@@ -42,6 +62,8 @@ class UserModel {
 
   @override
   String toString() {
-    return 'UserModel(id: $id, userName: $userName, password: $password)';
+    return 'UserModel(id: $id, userName: $userName, password: $password, userType: $role)';
   }
 }
+
+enum UserType { admin, user }

--- a/lib/features/auth/data/remote/auth_firebase_services.dart
+++ b/lib/features/auth/data/remote/auth_firebase_services.dart
@@ -1,5 +1,3 @@
-import 'dart:developer';
-
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:el_sharq_clinic/core/models/auth_data_model.dart';
 import 'package:el_sharq_clinic/features/auth/data/local/models/user_model.dart';
@@ -32,8 +30,6 @@ class AuthFirebaseServices {
             (user) => user.userName == userName && user.password == password,
             orElse: () => UserModel.empty(),
           );
-
-      log(user.toString());
 
       // If user exists
       if (!user.isEmpty) {
@@ -71,14 +67,63 @@ class AuthFirebaseServices {
   }
 
   Future<void> updatePreferences(AuthDataModel authData) async {
-    final DocumentReference _clinicDoc = FirebaseFirestore.instance
+    final DocumentReference clinicDoc = FirebaseFirestore.instance
         .collection('clinics')
         .doc('clinic${authData.clinicIndex}');
 
-    await _clinicDoc.update({
+    await clinicDoc.update({
+      'clinicName': authData.clinicName,
       'language': authData.language,
       'theme': authData.theme,
       'lowStockLimit': authData.lowStockLimit,
     });
+  }
+
+  Future<void> updateUserPassword(
+      AuthDataModel authData, String newPassword) async {
+    final DocumentReference clinicDoc = FirebaseFirestore.instance
+        .collection('clinics')
+        .doc('clinic${authData.clinicIndex}');
+
+    final DocumentReference userDoc = clinicDoc
+        .collection('users')
+        .doc(authData.userModel.id); // Get user document
+
+    await userDoc.update({
+      'password': newPassword,
+    });
+  }
+
+  Future<void> addUserAccount(AuthDataModel authData, UserModel newUser) async {
+    final DocumentReference clinicDoc =
+        _firestore.collection('clinics').doc('clinic${authData.clinicIndex}');
+
+    await clinicDoc
+        .collection('users')
+        .doc(newUser.id)
+        .set(newUser.toFirestore());
+  }
+
+  Future<void> deleteUserAccount(AuthDataModel authData, String userId) async {
+    final DocumentReference clinicDoc =
+        _firestore.collection('clinics').doc('clinic${authData.clinicIndex}');
+
+    await clinicDoc.collection('users').doc(userId).delete();
+  }
+
+  Future<List<UserModel>> getClinicUsers(AuthDataModel authData) async {
+    final clinicDoc = await _firestore
+        .collection('clinics')
+        .doc('clinic${authData.clinicIndex}')
+        .get();
+
+    final usersCollection = await _getNestedCollection<UserModel>(
+      clinicDoc,
+      'users',
+      (snapshot) => UserModel.fromFirestore(snapshot),
+      (user) => user.toFirestore(),
+    );
+
+    return usersCollection.docs.map((e) => e.data()).toList();
   }
 }

--- a/lib/features/auth/ui/widgets/auth_bloc_listener.dart
+++ b/lib/features/auth/ui/widgets/auth_bloc_listener.dart
@@ -33,9 +33,12 @@ class AuthBlocListener extends StatelessWidget {
               dialogType: DialogType.success,
             ),
           );
-          Future.delayed(const Duration(seconds: 2), () => context.pop()).then(
-              (_) =>
-                  context.pushNamed(AppRoutes.home, arguments: state.authData));
+          Future.delayed(const Duration(seconds: 2), () => context.pop())
+              .then((_) {
+            if (context.mounted) {
+              context.pushNamed(AppRoutes.home, arguments: state.authData);
+            }
+          });
         }
         if (state is AuthFailure) {
           if (ModalRoute.of(context)?.isCurrent != true) context.pop();

--- a/lib/features/dashboard/ui/widgets/today_sales_container.dart
+++ b/lib/features/dashboard/ui/widgets/today_sales_container.dart
@@ -1,5 +1,6 @@
 import 'package:el_sharq_clinic/core/helpers/spacing.dart';
 import 'package:el_sharq_clinic/core/theming/app_colors.dart';
+import 'package:el_sharq_clinic/core/theming/app_text_styles.dart';
 import 'package:el_sharq_clinic/features/dashboard/data/models/pie_chart_item_model.dart';
 import 'package:el_sharq_clinic/features/dashboard/ui/widgets/dashboard_stats_container.dart';
 import 'package:el_sharq_clinic/features/dashboard/ui/widgets/sales_pie_chart.dart';
@@ -38,11 +39,21 @@ class TodaySalesContainer extends StatelessWidget {
             ],
           ),
           pieChartData.isEmpty
-              ? const SizedBox.shrink()
+              ? _buildNoSalesText()
               : SalesPieChart(
                   items: pieChartData,
                 ),
         ],
+      ),
+    );
+  }
+
+  AspectRatio _buildNoSalesText() {
+    return const AspectRatio(
+      aspectRatio: 1.2,
+      child: Center(
+        child:
+            Text('No sales today', style: AppTextStyles.font22DarkGreyMedium),
       ),
     );
   }

--- a/lib/features/home/ui/home_layout.dart
+++ b/lib/features/home/ui/home_layout.dart
@@ -24,9 +24,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 class HomeLayout extends StatefulWidget {
-  const HomeLayout({super.key, required this.authData});
-
-  final AuthDataModel authData;
+  const HomeLayout({super.key});
 
   @override
   State<HomeLayout> createState() => _HomeLayoutState();
@@ -34,11 +32,12 @@ class HomeLayout extends StatefulWidget {
 
 class _HomeLayoutState extends State<HomeLayout> {
   int selectedDrawerItemIndex = 0;
+  late AuthDataModel authData;
 
   @override
   void initState() {
     super.initState();
-    context.read<MainCubit>().updateAuthData(widget.authData);
+    authData = context.read<MainCubit>().authData;
   }
 
   @override
@@ -46,7 +45,7 @@ class _HomeLayoutState extends State<HomeLayout> {
     final List drawerItems = _getDrawerWidgets;
     return Scaffold(
       backgroundColor: AppColors.lightBlue,
-      appBar: CustomAppBar(userName: widget.authData.userModel.userName),
+      appBar: const CustomAppBar(),
       body: Row(
         children: [
           Expanded(
@@ -80,17 +79,17 @@ class _HomeLayoutState extends State<HomeLayout> {
       (context) => BlocProvider(
             create: (context) => getIt<DashboardCubit>()
               ..setupSectionData(mainCubit.authData, mainCubit),
-            child: DashboardSection(authData: widget.authData),
+            child: DashboardSection(authData: authData),
           ),
       (context) => BlocProvider<CaseHistoryCubit>(
             create: (context) =>
                 getIt<CaseHistoryCubit>()..setupSectionData(mainCubit.authData),
-            child: CaseHistorySection(authData: widget.authData),
+            child: CaseHistorySection(authData: authData),
           ),
       (context) => BlocProvider<OwnersCubit>(
             create: (context) =>
                 getIt<OwnersCubit>()..setupSectionData(mainCubit.authData),
-            child: OwnersSection(authData: widget.authData),
+            child: OwnersSection(authData: authData),
           ),
       (context) => BlocProvider<DoctorsCubit>(
             create: (context) =>

--- a/lib/features/home/ui/widgets/custom_app_bar.dart
+++ b/lib/features/home/ui/widgets/custom_app_bar.dart
@@ -1,27 +1,39 @@
+import 'package:el_sharq_clinic/core/helpers/spacing.dart';
+import 'package:el_sharq_clinic/core/logic/cubit/main_cubit.dart';
+import 'package:el_sharq_clinic/core/models/auth_data_model.dart';
 import 'package:el_sharq_clinic/core/theming/app_colors.dart';
 import 'package:el_sharq_clinic/core/theming/app_text_styles.dart';
 import 'package:el_sharq_clinic/core/theming/assets.dart';
 import 'package:el_sharq_clinic/features/home/ui/widgets/app_bar_user_info.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 
 class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
-  const CustomAppBar({super.key, required this.userName});
-
-  final String userName;
+  const CustomAppBar({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 10),
-      decoration: _buildContainerDecoration(),
-      child: AppBar(
-        surfaceTintColor: AppColors.white,
-        backgroundColor: AppColors.white,
-        leading: Image.asset(Assets.assetsImagesPngIconLogo),
-        titleSpacing: 5,
-        title: _buildTitle(),
-        actions: [AppBarUserInfo(userName: userName)],
-      ),
+    return BlocSelector<MainCubit, MainState, AuthDataModel>(
+      selector: (state) {
+        return state.authDataModel;
+      },
+      builder: (context, authData) {
+        return Container(
+          padding: const EdgeInsets.symmetric(horizontal: 10),
+          decoration: _buildContainerDecoration(),
+          child: AppBar(
+            surfaceTintColor: AppColors.white,
+            backgroundColor: AppColors.white,
+            leading: _buildLeading(),
+            titleSpacing: 5,
+            title: _buildTitle(authData),
+            leadingWidth: 250.w,
+            centerTitle: true,
+            actions: [AppBarUserInfo(userName: authData.userModel.userName)],
+          ),
+        );
+      },
     );
   }
 
@@ -37,11 +49,26 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
     );
   }
 
-  Text _buildTitle() {
+  Row _buildLeading() {
+    return Row(
+      children: [
+        Image.asset(Assets.assetsImagesPngIconLogo),
+        horizontalSpace(20),
+        Text(
+          'EL-Sharq Clinic',
+          style: AppTextStyles.font22DarkGreyMedium.copyWith(
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Text _buildTitle(AuthDataModel authData) {
     return Text(
-      'EL-Sharq Clinic',
+      authData.clinicName,
       style: AppTextStyles.font22DarkGreyMedium.copyWith(
-        fontWeight: FontWeight.bold,
+        fontWeight: FontWeight.w500,
       ),
     );
   }

--- a/lib/features/settings/data/repos/settings_repo.dart
+++ b/lib/features/settings/data/repos/settings_repo.dart
@@ -1,4 +1,5 @@
 import 'package:el_sharq_clinic/core/models/auth_data_model.dart';
+import 'package:el_sharq_clinic/features/auth/data/local/models/user_model.dart';
 import 'package:el_sharq_clinic/features/auth/data/remote/auth_firebase_services.dart';
 
 class SettingsRepo {
@@ -8,5 +9,22 @@ class SettingsRepo {
 
   Future<void> updatePreferences(AuthDataModel authData) async {
     await _authFirebaseServices.updatePreferences(authData);
+  }
+
+  Future<void> updateUserPassword(
+      AuthDataModel authData, String newPassword) async {
+    await _authFirebaseServices.updateUserPassword(authData, newPassword);
+  }
+
+  Future<void> addUserAccount(UserModel newUser, AuthDataModel authData) async {
+    await _authFirebaseServices.addUserAccount(authData, newUser);
+  }
+
+  Future<void> deleteUserAccount(AuthDataModel authData, String userId) async {
+    await _authFirebaseServices.deleteUserAccount(authData, userId);
+  }
+
+  Future<List<UserModel>> getClinicUsers(AuthDataModel authData) async {
+    return await _authFirebaseServices.getClinicUsers(authData);
   }
 }

--- a/lib/features/settings/logic/cubit/settings_cubit.dart
+++ b/lib/features/settings/logic/cubit/settings_cubit.dart
@@ -1,8 +1,16 @@
+import 'dart:developer';
+
 import 'package:bloc/bloc.dart';
+import 'package:el_sharq_clinic/core/helpers/extensions.dart';
 import 'package:el_sharq_clinic/core/logic/cubit/main_cubit.dart';
 import 'package:el_sharq_clinic/core/models/auth_data_model.dart';
+import 'package:el_sharq_clinic/core/widgets/animated_loading_indicator.dart';
+import 'package:el_sharq_clinic/core/widgets/app_dialog.dart';
+import 'package:el_sharq_clinic/core/widgets/app_text_button.dart';
+import 'package:el_sharq_clinic/features/auth/data/local/models/user_model.dart';
 import 'package:el_sharq_clinic/features/settings/data/repos/settings_repo.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
 part 'settings_state.dart';
 
@@ -14,11 +22,23 @@ class SettingsCubit extends Cubit<SettingsState> {
   AuthDataModel? authData;
   AuthDataModel? newAuthData;
   ValueNotifier<bool> saveButtonState = ValueNotifier<bool>(false);
+  List<UserModel> clinicUsers = [];
 
   // Methods
-  void setupSectionData(AuthDataModel authData) {
+  void setupSectionData(AuthDataModel authData) async {
     this.authData = authData;
     newAuthData = authData;
+    await getClinicUsers(authData);
+  }
+
+  Future<void> getClinicUsers(AuthDataModel authData) async {
+    emit(SettingsLoading());
+    try {
+      clinicUsers = await _settingsRepo.getClinicUsers(authData);
+      emit(SettingsInitial());
+    } catch (e) {
+      emit(SettingsError('Failed to get users'));
+    }
   }
 
   // UI Methods
@@ -61,15 +81,115 @@ class SettingsCubit extends Cubit<SettingsState> {
 
   void onSavePreferences(MainCubit mainCubit) async {
     try {
+      emit(SettingsLoading());
+
       // Save preferences to firestore
       await _settingsRepo.updatePreferences(newAuthData!);
     } catch (e) {
-      emit(SettingsError(e.toString()));
+      emit(SettingsUpdatingError('Failed to update preferences'));
+
       return;
     }
-    // Update main cubit auth data
-    mainCubit.updateAuthData(newAuthData!);
     saveButtonState.value = false;
-    emit(SettingsUpdated());
+    emit(SettingsUpdated(
+        authData: newAuthData!,
+        message: 'Preferences updated successfully',
+        popCount: 0));
+  }
+
+  void onChangePassword(String password, String newPassword) async {
+    if (newPassword.trim().length < 6) {
+      log('Password must be at least 6 characters long');
+      emit(SettingsUpdatingError("Password must be at least 6 characters long",
+          popCount: 0));
+      return;
+    } else {
+      if (password == authData!.userModel.password) {
+        log('Correct password');
+        try {
+          emit(SettingsLoading());
+          await _settingsRepo.updateUserPassword(newAuthData!, newPassword);
+          newAuthData = newAuthData!.copyWith(
+              userModel:
+                  newAuthData!.userModel.copyWith(password: newPassword));
+          emit(SettingsUpdated(
+              authData: newAuthData!,
+              message: 'Password updated successfully'));
+        } catch (e) {
+          emit(SettingsUpdatingError('Failed to update password'));
+        }
+      } else {
+        log('Incorrect password');
+        emit(SettingsUpdatingError("The current password is incorrect",
+            popCount: 0));
+      }
+    }
+  }
+
+  void onClinicNameChanged(String clinicName) {
+    if (clinicName.trim() == newAuthData!.clinicName) return;
+    if (clinicName.trim().isEmpty) {
+      log('Clinic name cannot be empty');
+      emit(SettingsUpdatingError('Clinic name cannot be empty', popCount: 0));
+      return;
+    }
+    try {
+      emit(SettingsLoading());
+      newAuthData = newAuthData!.copyWith(clinicName: clinicName);
+      _settingsRepo.updatePreferences(newAuthData!);
+      emit(SettingsUpdated(
+          authData: newAuthData!, message: 'Clinic name updated successfully'));
+    } catch (e) {
+      emit(SettingsUpdatingError('Failed to update clinic name'));
+    }
+  }
+
+  void onAccountAdded(String accountName, String password) async {
+    if (accountName.trim().isEmpty || password.trim().isEmpty) {
+      emit(SettingsUpdatingError('Account name and password cannot be empty',
+          popCount: 0));
+      return;
+    } else if (password.trim().length < 6) {
+      emit(SettingsUpdatingError('Password must be at least 6 characters long',
+          popCount: 0));
+      return;
+    } else {
+      try {
+        emit(SettingsLoading());
+        UserModel newUserAccount = UserModel(
+          id: DateTime.now().millisecondsSinceEpoch.toString(),
+          userName: accountName,
+          password: password,
+          role: UserType.user,
+        );
+        await _settingsRepo.addUserAccount(newUserAccount, newAuthData!);
+        clinicUsers.insert(clinicUsers.length - 1, newUserAccount);
+        emit(SettingsUpdated(
+            authData: newAuthData!, message: 'Account added successfully'));
+      } catch (e) {
+        emit(SettingsUpdatingError('Failed to add account'));
+      }
+    }
+  }
+
+  void onAccountDeleted(String userId) async {
+    try {
+      emit(SettingsLoading());
+      await _settingsRepo.deleteUserAccount(newAuthData!, userId);
+      clinicUsers.removeWhere((element) => element.id == userId);
+      emit(SettingsUpdated(
+          message: 'Account deleted successfully',
+          authData: newAuthData!,
+          popCount: 0));
+    } catch (e) {
+      emit(SettingsUpdatingError('Failed to delete account'));
+    }
+  }
+
+  bool checkAdminPassword(String adminPassword) {
+    if (newAuthData!.userModel.password == adminPassword) {
+      return true;
+    }
+    return false;
   }
 }

--- a/lib/features/settings/logic/cubit/settings_state.dart
+++ b/lib/features/settings/logic/cubit/settings_state.dart
@@ -1,15 +1,84 @@
 part of 'settings_cubit.dart';
 
-abstract class SettingsState {}
+abstract class SettingsState {
+  void takeAction(BuildContext context) {}
+}
 
 final class SettingsInitial extends SettingsState {}
 
 final class SettingsChanged extends SettingsState {}
 
-final class SettingsUpdated extends SettingsState {}
+final class SettingsLoading extends SettingsState {
+  @override
+  void takeAction(BuildContext context) {
+    showDialog(
+        context: context,
+        builder: (context) => const AnimatedLoadingIndicator());
+  }
+}
 
 final class SettingsError extends SettingsState {
   final String message;
 
   SettingsError(this.message);
+}
+
+final class SettingsUpdated extends SettingsState {
+  final AuthDataModel authData;
+  final String message;
+  final int? popCount;
+
+  SettingsUpdated(
+      {required this.authData, required this.message, this.popCount = 1});
+
+  // Updating auth data in MainCubit
+  @override
+  void takeAction(BuildContext context) {
+    for (int i = 0; i < popCount!; i++) {
+      context.pop();
+    }
+    context.read<MainCubit>().updateAuthData(authData);
+    showDialog(
+        context: context,
+        barrierDismissible: false,
+        builder: (context) => AppDialog(
+              title: 'Success',
+              content: message,
+              dialogType: DialogType.success,
+            ));
+
+    Future.delayed(const Duration(seconds: 2), () {
+      if (context.mounted) {
+        context.pop();
+      }
+    });
+  }
+}
+
+final class SettingsUpdatingError extends SettingsState {
+  final String message;
+  final int popCount;
+
+  SettingsUpdatingError(this.message, {this.popCount = 1});
+
+  @override
+  void takeAction(BuildContext context) {
+    for (int i = 0; i < popCount; i++) {
+      context.pop();
+    }
+    showDialog(
+        context: context,
+        builder: (context) => AppDialog(
+              title: 'Error',
+              content: message,
+              dialogType: DialogType.error,
+              action: AppTextButton(
+                text: 'OK',
+                filled: false,
+                onPressed: () {
+                  context.pop();
+                },
+              ),
+            ));
+  }
 }

--- a/lib/features/settings/ui/settings_section.dart
+++ b/lib/features/settings/ui/settings_section.dart
@@ -3,6 +3,7 @@ import 'package:el_sharq_clinic/core/logic/cubit/main_cubit.dart';
 import 'package:el_sharq_clinic/core/widgets/app_text_button.dart';
 import 'package:el_sharq_clinic/core/widgets/section_container.dart';
 import 'package:el_sharq_clinic/features/settings/logic/cubit/settings_cubit.dart';
+import 'package:el_sharq_clinic/features/settings/ui/widgets/settings_bloc_listener.dart';
 import 'package:el_sharq_clinic/features/settings/ui/widgets/settings_body.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -39,6 +40,7 @@ class SettingsSection extends StatelessWidget {
           children: [
             verticalSpace(50),
             const Expanded(child: SettingsBody()),
+            const SettingsBlocListener(),
           ],
         ),
       ),

--- a/lib/features/settings/ui/widgets/add_user_account_dialog.dart
+++ b/lib/features/settings/ui/widgets/add_user_account_dialog.dart
@@ -5,8 +5,25 @@ import 'package:el_sharq_clinic/core/widgets/section_title.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 
-class AddUserAccountDialog extends StatelessWidget {
-  const AddUserAccountDialog({super.key});
+class AddUserAccountDialog extends StatefulWidget {
+  const AddUserAccountDialog({super.key, required this.onAccountAdded});
+
+  final void Function(String name, String password) onAccountAdded;
+
+  @override
+  State<AddUserAccountDialog> createState() => _AddUserAccountDialogState();
+}
+
+class _AddUserAccountDialogState extends State<AddUserAccountDialog> {
+  late TextEditingController _nameController;
+  late TextEditingController _passwordController;
+
+  @override
+  void initState() {
+    super.initState();
+    _nameController = TextEditingController();
+    _passwordController = TextEditingController();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -43,6 +60,7 @@ class AddUserAccountDialog extends StatelessWidget {
 
   AppTextField _buildNameTextField() {
     return AppTextField(
+      controller: _nameController,
       hint: 'Name',
       maxWidth: double.infinity,
       maxHeight: 90.h,
@@ -51,6 +69,7 @@ class AddUserAccountDialog extends StatelessWidget {
 
   AppTextField _buildPasswordTextField() {
     return AppTextField(
+      controller: _passwordController,
       hint: 'Password',
       isObscured: true,
       maxWidth: double.infinity,
@@ -71,7 +90,13 @@ class AddUserAccountDialog extends StatelessWidget {
         ),
         horizontalSpace(20),
         Expanded(
-          child: AppTextButton(height: 55.h, text: 'Add', onPressed: () {}),
+          child: AppTextButton(
+              height: 55.h,
+              text: 'Add',
+              onPressed: () {
+                widget.onAccountAdded(
+                    _nameController.text, _passwordController.text);
+              }),
         ),
       ],
     );

--- a/lib/features/settings/ui/widgets/admin_privileges_container.dart
+++ b/lib/features/settings/ui/widgets/admin_privileges_container.dart
@@ -1,0 +1,56 @@
+import 'package:el_sharq_clinic/core/helpers/spacing.dart';
+import 'package:el_sharq_clinic/features/settings/logic/cubit/settings_cubit.dart';
+import 'package:el_sharq_clinic/features/settings/ui/widgets/action_list_tile.dart';
+import 'package:el_sharq_clinic/features/settings/ui/widgets/add_user_account_dialog.dart';
+import 'package:el_sharq_clinic/features/settings/ui/widgets/change_clinic_name_dialog.dart';
+import 'package:el_sharq_clinic/features/settings/ui/widgets/users_expansion_tile.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+class AdminPrivilegesContainer extends StatelessWidget {
+  const AdminPrivilegesContainer({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final authData = context.watch<SettingsCubit>().newAuthData!;
+
+    return Column(
+      children: [
+        verticalSpace(20.h),
+        ActionListTile(
+          title: 'Change Clinic Name',
+          onTap: () => showClinicNameDialog(context, authData.clinicName),
+          iconData: Icons.edit,
+        ),
+        verticalSpace(20.h),
+        ActionListTile(
+          title: 'Add User Account',
+          onTap: () => showAddUserAccountDialog(context),
+          iconData: Icons.person_add,
+        ),
+        verticalSpace(20.h),
+        const UsersExpansionTile(),
+      ],
+    );
+  }
+
+  void showClinicNameDialog(BuildContext context, String clinicName) {
+    showDialog(
+      context: context,
+      builder: (_) => ChangeClinicNameDialog(
+        clinicName: clinicName,
+        onNameChanged: context.read<SettingsCubit>().onClinicNameChanged,
+      ),
+    );
+  }
+
+  void showAddUserAccountDialog(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (_) => AddUserAccountDialog(
+        onAccountAdded: context.read<SettingsCubit>().onAccountAdded,
+      ),
+    );
+  }
+}

--- a/lib/features/settings/ui/widgets/change_clinic_name_dialog.dart
+++ b/lib/features/settings/ui/widgets/change_clinic_name_dialog.dart
@@ -1,3 +1,4 @@
+import 'package:el_sharq_clinic/core/helpers/extensions.dart';
 import 'package:el_sharq_clinic/core/helpers/spacing.dart';
 import 'package:el_sharq_clinic/core/widgets/app_text_button.dart';
 import 'package:el_sharq_clinic/core/widgets/app_text_field.dart';
@@ -5,10 +6,25 @@ import 'package:el_sharq_clinic/core/widgets/section_title.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 
-class ChangeClinicNameDialog extends StatelessWidget {
-  const ChangeClinicNameDialog({super.key, required this.clinicName});
+class ChangeClinicNameDialog extends StatefulWidget {
+  const ChangeClinicNameDialog(
+      {super.key, required this.clinicName, required this.onNameChanged});
 
   final String clinicName;
+  final void Function(String clinicName) onNameChanged;
+
+  @override
+  State<ChangeClinicNameDialog> createState() => _ChangeClinicNameDialogState();
+}
+
+class _ChangeClinicNameDialogState extends State<ChangeClinicNameDialog> {
+  late TextEditingController _clinicNameController;
+
+  @override
+  void initState() {
+    super.initState();
+    _clinicNameController = TextEditingController(text: widget.clinicName);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -43,8 +59,8 @@ class ChangeClinicNameDialog extends StatelessWidget {
 
   AppTextField _buildClinicNameTextField() {
     return AppTextField(
+      controller: _clinicNameController,
       hint: 'Clinic Name',
-      initialValue: clinicName,
       maxWidth: double.infinity,
       maxHeight: 90.h,
     );
@@ -58,7 +74,7 @@ class ChangeClinicNameDialog extends StatelessWidget {
               height: 55.h,
               text: 'Cancel',
               onPressed: () {
-                Navigator.pop(context);
+                context.pop();
               }),
         ),
         horizontalSpace(20),
@@ -66,10 +82,18 @@ class ChangeClinicNameDialog extends StatelessWidget {
           child: AppTextButton(
             height: 55.h,
             text: 'Confirm',
-            onPressed: () {},
+            onPressed: () {
+              widget.onNameChanged(_clinicNameController.text);
+            },
           ),
         ),
       ],
     );
+  }
+
+  @override
+  void dispose() {
+    _clinicNameController.dispose();
+    super.dispose();
   }
 }

--- a/lib/features/settings/ui/widgets/change_password_dialog.dart
+++ b/lib/features/settings/ui/widgets/change_password_dialog.dart
@@ -1,12 +1,34 @@
+import 'package:el_sharq_clinic/core/helpers/extensions.dart';
 import 'package:el_sharq_clinic/core/helpers/spacing.dart';
+import 'package:el_sharq_clinic/core/widgets/app_dialog.dart';
 import 'package:el_sharq_clinic/core/widgets/app_text_button.dart';
 import 'package:el_sharq_clinic/core/widgets/app_text_field.dart';
 import 'package:el_sharq_clinic/core/widgets/section_title.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 
-class ChangePasswordDialog extends StatelessWidget {
-  const ChangePasswordDialog({super.key});
+class ChangePasswordDialog extends StatefulWidget {
+  const ChangePasswordDialog({super.key, required this.onPasswordChanged});
+
+  final void Function(String currentPassword, String newPassword)
+      onPasswordChanged;
+
+  @override
+  State<ChangePasswordDialog> createState() => _ChangePasswordDialogState();
+}
+
+class _ChangePasswordDialogState extends State<ChangePasswordDialog> {
+  late TextEditingController _currentPasswordController;
+  late TextEditingController _newPasswordController;
+  late TextEditingController _confirmNewPasswordController;
+
+  @override
+  void initState() {
+    super.initState();
+    _currentPasswordController = TextEditingController();
+    _newPasswordController = TextEditingController();
+    _confirmNewPasswordController = TextEditingController();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -20,91 +42,142 @@ class ChangePasswordDialog extends StatelessWidget {
       ),
     );
   }
-}
 
-Widget _buildDialogBody(BuildContext context) {
-  return Padding(
-    padding: EdgeInsets.symmetric(horizontal: 20.w),
-    child: Column(
-      mainAxisSize: MainAxisSize.min,
+  Widget _buildDialogBody(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.symmetric(horizontal: 20.w),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          verticalSpace(40),
+          const SectionTitle(title: 'Change Password'),
+          verticalSpace(30),
+          _buildCurrentPasswordTextField(),
+          verticalSpace(30),
+          _buildNewPasswordTextField(),
+          verticalSpace(30),
+          _buildConfirmNewPasswordTextField(),
+          const Spacer(),
+          _buildActionButtons(context),
+          verticalSpace(20),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCurrentPasswordTextField() {
+    return AppTextField(
+      controller: _currentPasswordController,
+      maxWidth: double.infinity,
+      hint: 'Current Password',
+      isObscured: true,
+      validator: (value) {
+        if (value!.isEmpty) {
+          return 'Please enter a password';
+        }
+        return null;
+      },
+    );
+  }
+
+  Widget _buildNewPasswordTextField() {
+    return AppTextField(
+      controller: _newPasswordController,
+      maxWidth: double.infinity,
+      hint: 'New Password',
+      isObscured: true,
+      validator: (value) {
+        if (value!.isEmpty) {
+          return 'Please enter a password';
+        }
+        return null;
+      },
+    );
+  }
+
+  Widget _buildConfirmNewPasswordTextField() {
+    return AppTextField(
+      controller: _confirmNewPasswordController,
+      maxWidth: double.infinity,
+      hint: 'Confirm New Password',
+      isObscured: true,
+      validator: (value) {
+        if (value!.isEmpty) {
+          return 'Please enter a password';
+        }
+        return null;
+      },
+    );
+  }
+
+  Widget _buildActionButtons(BuildContext context) {
+    return Row(
       children: [
-        verticalSpace(40),
-        const SectionTitle(title: 'Change Password'),
-        verticalSpace(30),
-        _buildCurrentPasswordTextField(),
-        verticalSpace(30),
-        _buildNewPasswordTextField(),
-        verticalSpace(30),
-        _buildConfirmNewPasswordTextField(),
-        const Spacer(),
-        _buildActionButtons(context),
-        verticalSpace(20),
-      ],
-    ),
-  );
-}
-
-Widget _buildCurrentPasswordTextField() {
-  return AppTextField(
-    maxWidth: double.infinity,
-    hint: 'Current Password',
-    isObscured: true,
-    validator: (value) {
-      if (value!.isEmpty) {
-        return 'Please enter a password';
-      }
-      return null;
-    },
-  );
-}
-
-Widget _buildNewPasswordTextField() {
-  return AppTextField(
-    maxWidth: double.infinity,
-    hint: 'New Password',
-    isObscured: true,
-    validator: (value) {
-      if (value!.isEmpty) {
-        return 'Please enter a password';
-      }
-      return null;
-    },
-  );
-}
-
-Widget _buildConfirmNewPasswordTextField() {
-  return AppTextField(
-    maxWidth: double.infinity,
-    hint: 'Confirm New Password',
-    isObscured: true,
-    validator: (value) {
-      if (value!.isEmpty) {
-        return 'Please enter a password';
-      }
-      return null;
-    },
-  );
-}
-
-Widget _buildActionButtons(BuildContext context) {
-  return Row(
-    children: [
-      Expanded(
-        child: AppTextButton(
-            height: 55.h,
-            text: 'Cancel',
-            onPressed: () {
-              Navigator.pop(context);
-            }),
-      ),
-      horizontalSpace(20),
-      Expanded(
-        child: AppTextButton(
-          height: 55.h,
-          text: 'Confirm',
-          onPressed: () {},
+        Expanded(
+          child: AppTextButton(
+              height: 55.h,
+              text: 'Cancel',
+              onPressed: () {
+                context.pop();
+              }),
         ),
-      ),
-    ],
-  );
+        horizontalSpace(20),
+        Expanded(
+          child: AppTextButton(
+            height: 55.h,
+            text: 'Confirm',
+            onPressed: () {
+              if (_validateInputs()) {
+                widget.onPasswordChanged(_currentPasswordController.text,
+                    _newPasswordController.text);
+                context.pop();
+              }
+            },
+          ),
+        ),
+      ],
+    );
+  }
+
+  bool _validateInputs() {
+    if (_currentPasswordController.text.isEmpty ||
+        _newPasswordController.text.isEmpty ||
+        _confirmNewPasswordController.text.isEmpty) {
+      showErrorDialog(context, 'Please fill in all fields');
+
+      return false;
+    }
+    if (_newPasswordController.text.trim() !=
+        _confirmNewPasswordController.text.trim()) {
+      showErrorDialog(context, 'Passwords do not match');
+
+      return false;
+    }
+    return true;
+  }
+
+  void showErrorDialog(BuildContext context, String message) {
+    showDialog(
+        context: context,
+        builder: (context) => AppDialog(
+              title: 'Error',
+              content: message,
+              dialogType: DialogType.error,
+              action: AppTextButton(
+                text: 'OK',
+                filled: false,
+                onPressed: () {
+                  context.pop();
+                },
+              ),
+            ));
+  }
+
+  @override
+  void dispose() {
+    _currentPasswordController.dispose();
+    _newPasswordController.dispose();
+    _confirmNewPasswordController.dispose();
+    super.dispose();
+  }
 }

--- a/lib/features/settings/ui/widgets/settings_bloc_listener.dart
+++ b/lib/features/settings/ui/widgets/settings_bloc_listener.dart
@@ -1,0 +1,19 @@
+import 'package:el_sharq_clinic/features/settings/logic/cubit/settings_cubit.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class SettingsBlocListener extends StatelessWidget {
+  const SettingsBlocListener({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<SettingsCubit, SettingsState>(
+      listenWhen: (previous, current) =>
+          current is SettingsUpdated || current is SettingsUpdatingError,
+      listener: (context, state) {
+        state.takeAction(context);
+      },
+      child: const SizedBox.shrink(),
+    );
+  }
+}


### PR DESCRIPTION
- Implemented settings firebase logic in `AuthFirebaseServices` & `SettingsRepo` & `SettingsCubit` classes.
- Added an abstract method called `takeAction` to the settings states to handle each state action should be taken.
- Created a `SettingsBlocListener` then added it into `SettingsSection` to listen to the changing of the settings states and take a specific action.
- Refactored the dialogs of the settings section to be a stateful widgets to handle its user inputs in an easily way.
- Created `AdminPrivilegesContianer` widget to hold the admin privileges that will be displayed only if the current user account id is equal to "admin".
- Added `copyWith` method to `UserModel` class.
- Refactored the `CustomAppBar` to have a current clinic name at the center.
- Wrapped `CustomAppBar` with bloc selector to rebuild it when the user change the clinic name in the settings section.
- Refactored the `TodaySalesContainer` widget to display empty message in case that there are no sales today.
- Refactored the app dialog message font size to be 20 instead of 16.