### PR TITLE
Finish Network Handling✅

### DIFF
--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -2,6 +2,7 @@ import 'package:el_sharq_clinic/core/di/dependency_injection.dart';
 import 'package:el_sharq_clinic/core/logic/cubit/main_cubit.dart';
 import 'package:el_sharq_clinic/core/models/auth_data_model.dart';
 import 'package:el_sharq_clinic/core/routing/app_routes.dart';
+import 'package:el_sharq_clinic/core/widgets/connectivity_monitor.dart';
 import 'package:el_sharq_clinic/features/auth/logic/cubit/auth_cubit.dart';
 import 'package:el_sharq_clinic/features/auth/ui/auth_screen.dart';
 import 'package:el_sharq_clinic/features/home/ui/home_layout.dart';
@@ -18,7 +19,7 @@ class AppRouter {
         return MaterialPageRoute(
           builder: (_) => BlocProvider<AuthCubit>(
             create: (context) => getIt<AuthCubit>()..setupInitialData(),
-            child: const AuthScreen(),
+            child: const ConnectivityMonitor(child: AuthScreen()),
           ),
         );
       case AppRoutes.home:
@@ -26,7 +27,7 @@ class AppRouter {
           builder: (_) => BlocProvider<MainCubit>(
             create: (context) => getIt<MainCubit>()
               ..setupInitialData(arguments as AuthDataModel),
-            child: const HomeLayout(),
+            child: const ConnectivityMonitor(child: HomeLayout()),
           ),
         );
       default:

--- a/lib/core/theming/assets.dart
+++ b/lib/core/theming/assets.dart
@@ -2,6 +2,18 @@
 class Assets {
   Assets._();
   
+  /// Assets for assetsImagesJsonDisconnectedAnimation
+  /// assets/images/json/disconnected_animation.json
+  static const String assetsImagesJsonDisconnectedAnimation = "assets/images/json/disconnected_animation.json";
+
+  /// Assets for assetsImagesJsonDogAnimation
+  /// assets/images/json/dog_animation.json
+  static const String assetsImagesJsonDogAnimation = "assets/images/json/dog_animation.json";
+
+  /// Assets for assetsImagesJsonLoadingAnimation
+  /// assets/images/json/loading_animation.gif
+  static const String assetsImagesJsonLoadingAnimation = "assets/images/json/loading_animation.gif";
+
   /// Assets for assetsImagesPngDebug
   /// assets/images/png/debug.log
   static const String assetsImagesPngDebug = "assets/images/png/debug.log";

--- a/lib/core/widgets/connectivity_monitor.dart
+++ b/lib/core/widgets/connectivity_monitor.dart
@@ -1,0 +1,95 @@
+import 'dart:async';
+import 'package:el_sharq_clinic/core/helpers/spacing.dart';
+import 'package:el_sharq_clinic/core/theming/app_colors.dart';
+import 'package:el_sharq_clinic/core/theming/app_text_styles.dart';
+import 'package:el_sharq_clinic/core/widgets/faded_animated_loading_icon.dart';
+import 'package:flutter/material.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+
+class ConnectivityMonitor extends StatefulWidget {
+  final Widget child;
+
+  const ConnectivityMonitor({super.key, required this.child});
+
+  @override
+  State<ConnectivityMonitor> createState() => _ConnectivityMonitorState();
+}
+
+class _ConnectivityMonitorState extends State<ConnectivityMonitor> {
+  late StreamSubscription<List<ConnectivityResult>> _connectivitySubscription;
+  bool _isConnected = true; // Assuming initially connected
+  late Widget displayedWidget;
+
+  @override
+  void initState() {
+    super.initState();
+    // Start listening to connectivity changes
+    _connectivitySubscription =
+        Connectivity().onConnectivityChanged.listen(_updateConnectionStatus);
+
+    displayedWidget = widget.child;
+  }
+
+  void _updateConnectionStatus(List<ConnectivityResult> result) async {
+    bool previousConnectionStatus = _isConnected;
+
+    if (result.contains(ConnectivityResult.wifi) ||
+        result.contains(ConnectivityResult.ethernet) ||
+        result.contains(ConnectivityResult.mobile)) {
+      _isConnected = true;
+    } else {
+      _isConnected = false;
+    }
+
+    // If connection status has changed, take the appropriate action
+    if (previousConnectionStatus != _isConnected) {
+      _handleConnectionChange();
+    }
+  }
+
+  void _handleConnectionChange() {
+    if (_isConnected) {
+      // Action when internet is restored
+      displayedWidget = widget.child;
+      setState(() {});
+    } else {
+      // Action when internet is lost
+      displayedWidget = _noConnectionWidget();
+      setState(() {});
+    }
+  }
+
+  @override
+  void dispose() {
+    _connectivitySubscription.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return displayedWidget;
+  }
+
+  Widget _noConnectionWidget() {
+    return Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const FadedAnimatedLoadingIcon(
+              iconData: Icons.wifi_off,
+              color: AppColors.darkGrey,
+            ),
+            verticalSpace(100),
+            Text(
+              'No Internet Connection',
+              style: AppTextStyles.font32DarkGreyMedium(context).copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/core/widgets/faded_animated_loading_icon.dart
+++ b/lib/core/widgets/faded_animated_loading_icon.dart
@@ -1,15 +1,20 @@
 import 'package:el_sharq_clinic/core/theming/app_colors.dart';
 import 'package:flutter/material.dart';
 
-class AnimatedLoadingIndicator extends StatefulWidget {
-  const AnimatedLoadingIndicator({super.key});
+class FadedAnimatedLoadingIcon extends StatefulWidget {
+  const FadedAnimatedLoadingIcon(
+      {super.key, this.iconData, this.size, this.color});
+
+  final IconData? iconData;
+  final double? size;
+  final Color? color;
 
   @override
-  State<AnimatedLoadingIndicator> createState() =>
-      _AnimatedLoadingIndicatorState();
+  State<FadedAnimatedLoadingIcon> createState() =>
+      _FadedAnimatedLoadingIconState();
 }
 
-class _AnimatedLoadingIndicatorState extends State<AnimatedLoadingIndicator>
+class _FadedAnimatedLoadingIconState extends State<FadedAnimatedLoadingIcon>
     with SingleTickerProviderStateMixin {
   late AnimationController _controller;
 
@@ -31,10 +36,10 @@ class _AnimatedLoadingIndicatorState extends State<AnimatedLoadingIndicator>
   Widget build(BuildContext context) {
     return FadeTransition(
         opacity: _controller,
-        child: const Icon(
-          Icons.pets,
-          size: 60,
-          color: AppColors.blue,
+        child: Icon(
+          widget.iconData ?? Icons.pets,
+          size: widget.size ?? 60,
+          color: widget.color ?? AppColors.blue,
         ));
   }
 }

--- a/lib/features/auth/logic/cubit/auth_cubit.dart
+++ b/lib/features/auth/logic/cubit/auth_cubit.dart
@@ -6,7 +6,7 @@ import 'package:el_sharq_clinic/core/helpers/extensions.dart';
 import 'package:el_sharq_clinic/core/helpers/strings.dart';
 import 'package:el_sharq_clinic/core/models/auth_data_model.dart';
 import 'package:el_sharq_clinic/core/routing/app_routes.dart';
-import 'package:el_sharq_clinic/core/widgets/animated_loading_indicator.dart';
+import 'package:el_sharq_clinic/core/widgets/faded_animated_loading_icon.dart';
 import 'package:el_sharq_clinic/core/widgets/app_dialog.dart';
 import 'package:el_sharq_clinic/core/widgets/app_text_button.dart';
 import 'package:el_sharq_clinic/features/auth/data/local/repos/auth_repo.dart';

--- a/lib/features/auth/logic/cubit/auth_state.dart
+++ b/lib/features/auth/logic/cubit/auth_state.dart
@@ -13,7 +13,7 @@ final class AuthLoading extends AuthState {
         context: context,
         barrierDismissible: false,
         builder: (context) {
-          return const Center(child: AnimatedLoadingIndicator());
+          return const Center(child: FadedAnimatedLoadingIcon());
         });
   }
 }

--- a/lib/features/cases/logic/cubit/case_history_cubit.dart
+++ b/lib/features/cases/logic/cubit/case_history_cubit.dart
@@ -3,7 +3,7 @@ import 'package:el_sharq_clinic/core/helpers/constants.dart';
 import 'package:el_sharq_clinic/core/helpers/extensions.dart';
 import 'package:el_sharq_clinic/core/helpers/strings.dart';
 import 'package:el_sharq_clinic/core/models/auth_data_model.dart';
-import 'package:el_sharq_clinic/core/widgets/animated_loading_indicator.dart';
+import 'package:el_sharq_clinic/core/widgets/faded_animated_loading_icon.dart';
 import 'package:el_sharq_clinic/core/widgets/app_dialog.dart';
 import 'package:el_sharq_clinic/core/widgets/app_text_button.dart';
 import 'package:el_sharq_clinic/features/cases/data/local/models/case_history_model.dart';

--- a/lib/features/cases/logic/cubit/case_history_state.dart
+++ b/lib/features/cases/logic/cubit/case_history_state.dart
@@ -76,7 +76,7 @@ final class NewCaseHistoryLoading extends CaseHistoryState {
         context: context,
         barrierDismissible: false,
         builder: (context) {
-          return const Center(child: AnimatedLoadingIndicator());
+          return const Center(child: FadedAnimatedLoadingIcon());
         });
   }
 }

--- a/lib/features/cases/ui/widgets/case_history_body.dart
+++ b/lib/features/cases/ui/widgets/case_history_body.dart
@@ -3,7 +3,7 @@ import 'package:el_sharq_clinic/core/helpers/constants.dart';
 import 'package:el_sharq_clinic/core/helpers/strings.dart';
 import 'package:el_sharq_clinic/core/theming/app_colors.dart';
 import 'package:el_sharq_clinic/core/theming/app_text_styles.dart';
-import 'package:el_sharq_clinic/core/widgets/animated_loading_indicator.dart';
+import 'package:el_sharq_clinic/core/widgets/faded_animated_loading_icon.dart';
 import 'package:el_sharq_clinic/core/widgets/custom_table.dart';
 import 'package:el_sharq_clinic/core/widgets/custom_table_data_source.dart';
 import 'package:el_sharq_clinic/core/widgets/section_details_container.dart';
@@ -52,7 +52,7 @@ class _CaseHistoryBodyState extends State<CaseHistoryBody> {
       );
     }
 
-    return const Center(child: AnimatedLoadingIndicator());
+    return const Center(child: FadedAnimatedLoadingIcon());
   }
 
   CustomTable _buildSuccess(BuildContext context, CaseHistoryState state) {

--- a/lib/features/dashboard/ui/widgets/cases_bar_chart.dart
+++ b/lib/features/dashboard/ui/widgets/cases_bar_chart.dart
@@ -136,10 +136,11 @@ class CasesBarChartState extends State<CasesBarChart> {
         x: index,
         barRods: [
           BarChartRodData(
-            width: 30,
+            width: 40,
             backDrawRodData:
                 touchedIndex == index ? backgroundBarChartRodData : null,
             toY: entry.value.toDouble(),
+            borderRadius: BorderRadius.circular(10),
             color: AppColors.blue.withOpacity(0.85),
             gradient: touchedIndex == index ? gradient : null,
           )

--- a/lib/features/dashboard/ui/widgets/dashboard_body.dart
+++ b/lib/features/dashboard/ui/widgets/dashboard_body.dart
@@ -1,7 +1,7 @@
 import 'package:animate_do/animate_do.dart';
 import 'package:el_sharq_clinic/core/helpers/spacing.dart';
 import 'package:el_sharq_clinic/core/theming/app_text_styles.dart';
-import 'package:el_sharq_clinic/core/widgets/animated_loading_indicator.dart';
+import 'package:el_sharq_clinic/core/widgets/faded_animated_loading_icon.dart';
 import 'package:el_sharq_clinic/core/widgets/section_details_container.dart';
 import 'package:el_sharq_clinic/features/dashboard/logic/cubit/dashboard_cubit.dart';
 import 'package:el_sharq_clinic/features/dashboard/ui/widgets/cases_last_week.dart';
@@ -46,7 +46,7 @@ class DashboardBody extends StatelessWidget {
 
   Center _buildLoading() {
     return const Center(
-      child: AnimatedLoadingIndicator(),
+      child: FadedAnimatedLoadingIcon(),
     );
   }
 

--- a/lib/features/dashboard/ui/widgets/highlights_row.dart
+++ b/lib/features/dashboard/ui/widgets/highlights_row.dart
@@ -61,7 +61,7 @@ class TodayHighlightsRow extends StatelessWidget {
           title: AppStrings.revenue.tr(),
           value: revenue,
           iconData: Icons.monetization_on,
-          decimals: 2,
+          decimals: 1,
         ),
       ),
     ];

--- a/lib/features/doctors/logic/cubit/doctors_cubit.dart
+++ b/lib/features/doctors/logic/cubit/doctors_cubit.dart
@@ -5,7 +5,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:el_sharq_clinic/core/helpers/extensions.dart';
 import 'package:el_sharq_clinic/core/helpers/strings.dart';
 import 'package:el_sharq_clinic/core/models/auth_data_model.dart';
-import 'package:el_sharq_clinic/core/widgets/animated_loading_indicator.dart';
+import 'package:el_sharq_clinic/core/widgets/faded_animated_loading_icon.dart';
 import 'package:el_sharq_clinic/core/widgets/app_dialog.dart';
 import 'package:el_sharq_clinic/core/widgets/app_text_button.dart';
 import 'package:el_sharq_clinic/features/doctors/data/models/doctor_model.dart';

--- a/lib/features/doctors/logic/cubit/doctors_state.dart
+++ b/lib/features/doctors/logic/cubit/doctors_state.dart
@@ -44,7 +44,7 @@ final class DoctorLoading extends DoctorsState {
         context: context,
         barrierDismissible: false,
         builder: (context) {
-          return const Center(child: AnimatedLoadingIndicator());
+          return const Center(child: FadedAnimatedLoadingIcon());
         });
   }
 }

--- a/lib/features/doctors/ui/widgets/doctors_body.dart
+++ b/lib/features/doctors/ui/widgets/doctors_body.dart
@@ -2,7 +2,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:el_sharq_clinic/core/helpers/constants.dart';
 import 'package:el_sharq_clinic/core/helpers/strings.dart';
 import 'package:el_sharq_clinic/core/theming/app_colors.dart';
-import 'package:el_sharq_clinic/core/widgets/animated_loading_indicator.dart';
+import 'package:el_sharq_clinic/core/widgets/faded_animated_loading_icon.dart';
 import 'package:el_sharq_clinic/core/widgets/custom_table.dart';
 import 'package:el_sharq_clinic/core/widgets/custom_table_data_source.dart';
 import 'package:el_sharq_clinic/core/widgets/section_details_container.dart';
@@ -47,7 +47,7 @@ class _DoctorsBodyState extends State<DoctorsBody> {
         child: Text(state.message),
       );
     }
-    return const Center(child: AnimatedLoadingIndicator());
+    return const Center(child: FadedAnimatedLoadingIcon());
   }
 
   CustomTable _buildSuccess(BuildContext context, DoctorsState state) {

--- a/lib/features/invoices/logic/cubit/invoices_cubit.dart
+++ b/lib/features/invoices/logic/cubit/invoices_cubit.dart
@@ -5,7 +5,7 @@ import 'package:el_sharq_clinic/core/helpers/strings.dart';
 import 'package:el_sharq_clinic/core/logic/cubit/main_cubit.dart';
 import 'package:el_sharq_clinic/core/models/auth_data_model.dart';
 import 'package:el_sharq_clinic/core/models/selable_item_model.dart';
-import 'package:el_sharq_clinic/core/widgets/animated_loading_indicator.dart';
+import 'package:el_sharq_clinic/core/widgets/faded_animated_loading_icon.dart';
 import 'package:el_sharq_clinic/core/widgets/app_dialog.dart';
 import 'package:el_sharq_clinic/core/widgets/app_text_button.dart';
 import 'package:el_sharq_clinic/features/auth/data/local/models/user_model.dart';

--- a/lib/features/invoices/logic/cubit/invoices_state.dart
+++ b/lib/features/invoices/logic/cubit/invoices_state.dart
@@ -63,7 +63,7 @@ final class InvoiceInProgress extends InvoicesState {
         context: context,
         barrierDismissible: false,
         builder: (context) {
-          return const Center(child: AnimatedLoadingIndicator());
+          return const Center(child: FadedAnimatedLoadingIcon());
         });
   }
 }

--- a/lib/features/invoices/ui/widgets/invoices_body.dart
+++ b/lib/features/invoices/ui/widgets/invoices_body.dart
@@ -2,7 +2,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:el_sharq_clinic/core/helpers/constants.dart';
 import 'package:el_sharq_clinic/core/helpers/strings.dart';
 import 'package:el_sharq_clinic/core/theming/app_colors.dart';
-import 'package:el_sharq_clinic/core/widgets/animated_loading_indicator.dart';
+import 'package:el_sharq_clinic/core/widgets/faded_animated_loading_icon.dart';
 import 'package:el_sharq_clinic/core/widgets/custom_table.dart';
 import 'package:el_sharq_clinic/core/widgets/custom_table_data_source.dart';
 import 'package:el_sharq_clinic/core/widgets/section_details_container.dart';
@@ -46,7 +46,7 @@ class _InvoicesBodyState extends State<InvoicesBody> {
         child: Text(state.message),
       );
     }
-    return const Center(child: AnimatedLoadingIndicator());
+    return const Center(child: FadedAnimatedLoadingIcon());
   }
 
   CustomTable _buildSuccess(InvoicesState state) {

--- a/lib/features/owners/logic/cubit/owners_cubit.dart
+++ b/lib/features/owners/logic/cubit/owners_cubit.dart
@@ -3,7 +3,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:el_sharq_clinic/core/helpers/extensions.dart';
 import 'package:el_sharq_clinic/core/helpers/strings.dart';
 import 'package:el_sharq_clinic/core/models/auth_data_model.dart';
-import 'package:el_sharq_clinic/core/widgets/animated_loading_indicator.dart';
+import 'package:el_sharq_clinic/core/widgets/faded_animated_loading_icon.dart';
 import 'package:el_sharq_clinic/core/widgets/app_dialog.dart';
 import 'package:el_sharq_clinic/core/widgets/app_text_button.dart';
 import 'package:el_sharq_clinic/features/owners/data/local/models/owner_model.dart';

--- a/lib/features/owners/logic/cubit/owners_state.dart
+++ b/lib/features/owners/logic/cubit/owners_state.dart
@@ -53,7 +53,7 @@ final class OwnerLoading extends OwnersState {
         context: context,
         barrierDismissible: false,
         builder: (context) {
-          return const Center(child: AnimatedLoadingIndicator());
+          return const Center(child: FadedAnimatedLoadingIcon());
         });
   }
 }

--- a/lib/features/owners/ui/widgets/owners_body.dart
+++ b/lib/features/owners/ui/widgets/owners_body.dart
@@ -2,7 +2,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:el_sharq_clinic/core/helpers/constants.dart';
 import 'package:el_sharq_clinic/core/helpers/strings.dart';
 import 'package:el_sharq_clinic/core/theming/app_colors.dart';
-import 'package:el_sharq_clinic/core/widgets/animated_loading_indicator.dart';
+import 'package:el_sharq_clinic/core/widgets/faded_animated_loading_icon.dart';
 import 'package:el_sharq_clinic/core/widgets/custom_table.dart';
 import 'package:el_sharq_clinic/core/widgets/custom_table_data_source.dart';
 import 'package:el_sharq_clinic/core/widgets/section_details_container.dart';
@@ -47,7 +47,7 @@ class _OwnersBodyState extends State<OwnersBody> {
         child: Text(state.message),
       );
     }
-    return const Center(child: AnimatedLoadingIndicator());
+    return const Center(child: FadedAnimatedLoadingIcon());
   }
 
   CustomTable _buildSuccess(OwnersState state) {

--- a/lib/features/products/logic/cubit/products_cubit.dart
+++ b/lib/features/products/logic/cubit/products_cubit.dart
@@ -4,7 +4,7 @@ import 'package:el_sharq_clinic/core/helpers/extensions.dart';
 import 'package:el_sharq_clinic/core/helpers/strings.dart';
 import 'package:el_sharq_clinic/core/logic/cubit/main_cubit.dart';
 import 'package:el_sharq_clinic/core/models/auth_data_model.dart';
-import 'package:el_sharq_clinic/core/widgets/animated_loading_indicator.dart';
+import 'package:el_sharq_clinic/core/widgets/faded_animated_loading_icon.dart';
 import 'package:el_sharq_clinic/core/widgets/app_dialog.dart';
 import 'package:el_sharq_clinic/core/widgets/app_text_button.dart';
 import 'package:el_sharq_clinic/features/products/data/models/product_model.dart';

--- a/lib/features/products/logic/cubit/products_state.dart
+++ b/lib/features/products/logic/cubit/products_state.dart
@@ -51,7 +51,7 @@ final class ProductInProgress extends ProductsState {
         context: context,
         barrierDismissible: false,
         builder: (context) {
-          return const Center(child: AnimatedLoadingIndicator());
+          return const Center(child: FadedAnimatedLoadingIcon());
         });
   }
 }

--- a/lib/features/products/ui/widgets/products_body.dart
+++ b/lib/features/products/ui/widgets/products_body.dart
@@ -2,7 +2,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:el_sharq_clinic/core/helpers/strings.dart';
 import 'package:el_sharq_clinic/core/theming/app_colors.dart';
 import 'package:el_sharq_clinic/core/theming/app_text_styles.dart';
-import 'package:el_sharq_clinic/core/widgets/animated_loading_indicator.dart';
+import 'package:el_sharq_clinic/core/widgets/faded_animated_loading_icon.dart';
 import 'package:el_sharq_clinic/core/widgets/app_grid_view.dart';
 import 'package:el_sharq_clinic/core/widgets/section_details_container.dart';
 import 'package:el_sharq_clinic/features/products/data/models/product_model.dart';
@@ -52,7 +52,7 @@ class ProductsBody extends StatelessWidget {
     } else if (state is ProductsSearchSuccess) {
       return _buildSuccess(context, state.products, state.selectedProductType);
     } else {
-      return const AnimatedLoadingIndicator();
+      return const FadedAnimatedLoadingIcon();
     }
   }
 

--- a/lib/features/services/logic/cubit/services_cubit.dart
+++ b/lib/features/services/logic/cubit/services_cubit.dart
@@ -5,7 +5,7 @@ import 'package:el_sharq_clinic/core/helpers/strings.dart';
 import 'package:el_sharq_clinic/core/logic/cubit/main_cubit.dart';
 import 'package:el_sharq_clinic/core/models/auth_data_model.dart';
 import 'package:el_sharq_clinic/core/theming/assets.dart';
-import 'package:el_sharq_clinic/core/widgets/animated_loading_indicator.dart';
+import 'package:el_sharq_clinic/core/widgets/faded_animated_loading_icon.dart';
 import 'package:el_sharq_clinic/core/widgets/app_dialog.dart';
 import 'package:el_sharq_clinic/core/widgets/app_text_button.dart';
 import 'package:el_sharq_clinic/features/services/data/models/service_model.dart';

--- a/lib/features/services/logic/cubit/services_state.dart
+++ b/lib/features/services/logic/cubit/services_state.dart
@@ -58,7 +58,7 @@ final class ServiceSaving extends ServicesState {
         context: context,
         barrierDismissible: false,
         builder: (context) {
-          return const Center(child: AnimatedLoadingIndicator());
+          return const Center(child: FadedAnimatedLoadingIcon());
         });
   }
 }

--- a/lib/features/services/ui/widgets/services_body.dart
+++ b/lib/features/services/ui/widgets/services_body.dart
@@ -2,7 +2,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:el_sharq_clinic/core/helpers/strings.dart';
 import 'package:el_sharq_clinic/core/theming/app_colors.dart';
 import 'package:el_sharq_clinic/core/theming/app_text_styles.dart';
-import 'package:el_sharq_clinic/core/widgets/animated_loading_indicator.dart';
+import 'package:el_sharq_clinic/core/widgets/faded_animated_loading_icon.dart';
 import 'package:el_sharq_clinic/core/widgets/app_grid_view.dart';
 import 'package:el_sharq_clinic/core/widgets/section_details_container.dart';
 import 'package:el_sharq_clinic/features/services/data/models/service_model.dart';
@@ -42,7 +42,7 @@ class ServicesBody extends StatelessWidget {
     );
   }
 
-  Center _buildLoading() => const Center(child: AnimatedLoadingIndicator());
+  Center _buildLoading() => const Center(child: FadedAnimatedLoadingIcon());
 
   Center _buildError(ServicesError state, BuildContext context) {
     return Center(

--- a/lib/features/settings/logic/cubit/settings_cubit.dart
+++ b/lib/features/settings/logic/cubit/settings_cubit.dart
@@ -4,7 +4,7 @@ import 'package:el_sharq_clinic/core/helpers/extensions.dart';
 import 'package:el_sharq_clinic/core/helpers/strings.dart';
 import 'package:el_sharq_clinic/core/logic/cubit/main_cubit.dart';
 import 'package:el_sharq_clinic/core/models/auth_data_model.dart';
-import 'package:el_sharq_clinic/core/widgets/animated_loading_indicator.dart';
+import 'package:el_sharq_clinic/core/widgets/faded_animated_loading_icon.dart';
 import 'package:el_sharq_clinic/core/widgets/app_dialog.dart';
 import 'package:el_sharq_clinic/core/widgets/app_text_button.dart';
 import 'package:el_sharq_clinic/features/auth/data/local/models/user_model.dart';

--- a/lib/features/settings/logic/cubit/settings_state.dart
+++ b/lib/features/settings/logic/cubit/settings_state.dart
@@ -13,7 +13,7 @@ final class SettingsLoading extends SettingsState {
   void takeAction(BuildContext context) {
     showDialog(
         context: context,
-        builder: (context) => const AnimatedLoadingIndicator());
+        builder: (context) => const FadedAnimatedLoadingIcon());
   }
 }
 

--- a/lib/features/settings/ui/widgets/settings_body.dart
+++ b/lib/features/settings/ui/widgets/settings_body.dart
@@ -5,7 +5,7 @@ import 'package:el_sharq_clinic/core/helpers/strings.dart';
 import 'package:el_sharq_clinic/core/models/auth_data_model.dart';
 import 'package:el_sharq_clinic/core/theming/app_colors.dart';
 import 'package:el_sharq_clinic/core/theming/app_text_styles.dart';
-import 'package:el_sharq_clinic/core/widgets/animated_loading_indicator.dart';
+import 'package:el_sharq_clinic/core/widgets/faded_animated_loading_icon.dart';
 import 'package:el_sharq_clinic/core/widgets/app_text_field.dart';
 import 'package:el_sharq_clinic/core/widgets/section_details_container.dart';
 import 'package:el_sharq_clinic/features/auth/data/local/models/user_model.dart';
@@ -60,7 +60,7 @@ class SettingsBody extends StatelessWidget {
 
   Center _buildLoading() {
     return const Center(
-      child: AnimatedLoadingIndicator(),
+      child: FadedAnimatedLoadingIcon(),
     );
   }
 

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,6 +6,7 @@ import FlutterMacOS
 import Foundation
 
 import cloud_firestore
+import connectivity_plus
 import firebase_core
 import printing
 import screen_retriever
@@ -14,6 +15,7 @@ import window_manager
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseFirestorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseFirestorePlugin"))
+  ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
   PrintingPlugin.register(with: registry.registrar(forPlugin: "PrintingPlugin"))
   ScreenRetrieverPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -121,6 +121,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.18.0"
+  connectivity_plus:
+    dependency: "direct main"
+    description:
+      name: connectivity_plus
+      sha256: "2056db5241f96cdc0126bd94459fc4cdc13876753768fc7a31c425e50a7177d0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.5"
+  connectivity_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: connectivity_plus_platform_interface
+      sha256: "42657c1715d48b167930d5f34d00222ac100475f73d10162ddf43e714932f204"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   crypto:
     dependency: transitive
     description:
@@ -145,6 +161,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.5.15"
+  dbus:
+    dependency: transitive
+    description:
+      name: dbus
+      sha256: "365c771ac3b0e58845f39ec6deebc76e3276aa9922b0cc60840712094d9047ac"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.10"
   easy_localization:
     dependency: "direct main"
     description:
@@ -421,6 +445,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  nm:
+    dependency: transitive
+    description:
+      name: nm
+      sha256: "2c9aae4127bdc8993206464fcc063611e0e36e72018696cd9631023a31b24254"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
   path:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,6 +47,7 @@ dependencies:
   printing: ^5.13.1
   animate_do: ^3.3.4
   easy_localization: ^3.0.7
+  connectivity_plus: ^6.0.5
 
 dev_dependencies:
   flutter_lints: ^4.0.0

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -7,6 +7,7 @@
 #include "generated_plugin_registrant.h"
 
 #include <cloud_firestore/cloud_firestore_plugin_c_api.h>
+#include <connectivity_plus/connectivity_plus_windows_plugin.h>
 #include <firebase_core/firebase_core_plugin_c_api.h>
 #include <printing/printing_plugin.h>
 #include <screen_retriever/screen_retriever_plugin.h>
@@ -15,6 +16,8 @@
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   CloudFirestorePluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("CloudFirestorePluginCApi"));
+  ConnectivityPlusWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("ConnectivityPlusWindowsPlugin"));
   FirebaseCorePluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FirebaseCorePluginCApi"));
   PrintingPluginRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   cloud_firestore
+  connectivity_plus
   firebase_core
   printing
   screen_retriever


### PR DESCRIPTION
- Added `connectivity_plus` package into pubspec.yaml file.
- Created the `ConnectivityMonitor` widget to watch the network state of the app and take actions depends on it.
- Wrapped the `AuthScreen` & `HomeLayout` widgets with `ConnectivityMonitor` widget.
- Refactored the `AnimatedLoadingIndicator` to be `FadedAnimatedLoadingIcon` and make it receive an icon data, color and size to be reusable.